### PR TITLE
Environment setup

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -1,0 +1,27 @@
+import { env } from "../src/typeDefinitions/default.types";
+import {
+  RDS_BASE_API_URL,
+  RDS_BASE_STAGING_API_URL,
+  RDS_BASE_DEVELOPMENT_API_URL,
+} from "../src/constants/urls";
+
+const config = (env: env) => {
+  const environment = { RDS_BASE_API_URL: "" };
+
+  switch (env.CURRENT_ENVIRONMENT) {
+    case "production":
+      environment.RDS_BASE_API_URL = RDS_BASE_API_URL;
+      break;
+
+    case "staging":
+      environment.RDS_BASE_API_URL = RDS_BASE_STAGING_API_URL;
+      break;
+
+    default:
+      environment.RDS_BASE_API_URL = RDS_BASE_DEVELOPMENT_API_URL;
+  }
+
+  return environment;
+};
+
+export default config;

--- a/config/config.ts
+++ b/config/config.ts
@@ -1,4 +1,4 @@
-import { env } from "../src/typeDefinitions/default.types";
+import { env, environment } from "../src/typeDefinitions/default.types";
 import {
   RDS_BASE_API_URL,
   RDS_BASE_STAGING_API_URL,
@@ -6,22 +6,19 @@ import {
 } from "../src/constants/urls";
 
 const config = (env: env) => {
-  const environment = { RDS_BASE_API_URL: "" };
+  const environment: environment = {
+    production: {
+      RDS_BASE_API_URL: RDS_BASE_API_URL,
+    },
+    staging: {
+      RDS_BASE_API_URL: RDS_BASE_STAGING_API_URL,
+    },
+    default: {
+      RDS_BASE_API_URL: RDS_BASE_DEVELOPMENT_API_URL,
+    },
+  };
 
-  switch (env.CURRENT_ENVIRONMENT) {
-    case "production":
-      environment.RDS_BASE_API_URL = RDS_BASE_API_URL;
-      break;
-
-    case "staging":
-      environment.RDS_BASE_API_URL = RDS_BASE_STAGING_API_URL;
-      break;
-
-    default:
-      environment.RDS_BASE_API_URL = RDS_BASE_DEVELOPMENT_API_URL;
-  }
-
-  return environment;
+  return environment[env.CURRENT_ENVIRONMENT] || environment.default;
 };
 
 export default config;

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,3 +1,6 @@
-export const RDS_API_BASE_URL = "https://api.realdevsquad.com";
+export const RDS_BASE_API_URL = "https://api.realdevsquad.com";
+export const RDS_BASE_STAGING_API_URL = "https://staging-api.realdevsquad.com";
+export const RDS_BASE_DEVELOPMENT_API_URL = "http://localhost:3000"; // If needed, modify the URL to your local API server
+
 export const DISCORD_BASE_URL = "https://discord.com/api/v10";
 export const VERIFICATION_SITE_URL = "https://my.realdevsquad.com";

--- a/src/typeDefinitions/default.types.d.ts
+++ b/src/typeDefinitions/default.types.d.ts
@@ -2,6 +2,14 @@ export interface env {
   [key: string]: string;
 }
 
+export interface environment {
+  [key: string]: variables;
+}
+
+export interface variables {
+  RDS_BASE_API_URL: string;
+}
+
 export interface discordCommand {
   name: string;
   description: string;

--- a/tests/fixtures/config.ts
+++ b/tests/fixtures/config.ts
@@ -1,0 +1,11 @@
+export const environment = [
+  {
+    CURRENT_ENVIRONMENT: "production",
+  },
+  {
+    CURRENT_ENVIRONMENT: "staging",
+  },
+  {
+    CURRENT_ENVIRONMENT: "",
+  },
+];

--- a/tests/unit/config/config.test.ts
+++ b/tests/unit/config/config.test.ts
@@ -1,0 +1,25 @@
+import config from "../../../config/config";
+import { environment } from "../../fixtures/config";
+import {
+  RDS_BASE_API_URL,
+  RDS_BASE_DEVELOPMENT_API_URL,
+  RDS_BASE_STAGING_API_URL,
+} from "../../../src/constants/urls";
+
+describe("Test config function", () => {
+  it("Should return production config environment", () => {
+    expect(config(environment[0]).RDS_BASE_API_URL).toBe(RDS_BASE_API_URL);
+  });
+
+  it("Should return staging config environment", () => {
+    expect(config(environment[1]).RDS_BASE_API_URL).toBe(
+      RDS_BASE_STAGING_API_URL
+    );
+  });
+
+  it("Should return default config environment", () => {
+    expect(config(environment[2]).RDS_BASE_API_URL).toBe(
+      RDS_BASE_DEVELOPMENT_API_URL
+    );
+  });
+});


### PR DESCRIPTION
## Issue
Closes #39

## What's the change
- Created a function which switches the environment properties like BASE_API urls according to the environment being used.
- The environments currently supported are production, staging and development (also, default)   
- Written tests for the created function
