### PR TITLE
Add a patch URL to change nickname

### DIFF
--- a/src/constants/responses.ts
+++ b/src/constants/responses.ts
@@ -24,4 +24,4 @@ export const RETRY_COMMAND =
 
 export const ROLE_ADDED = "Role added successfully";
 
-export const NAME_CHANGED = "User nickname change successful";
+export const NAME_CHANGED = "User nickname changed successfully";

--- a/src/constants/responses.ts
+++ b/src/constants/responses.ts
@@ -23,3 +23,5 @@ export const RETRY_COMMAND =
   "Oops, we didn't catch that! Please use the command again.";
 
 export const ROLE_ADDED = "Role added successfully";
+
+export const NAME_CHANGED = "User nickname change successful";

--- a/src/controllers/changeNickname.ts
+++ b/src/controllers/changeNickname.ts
@@ -1,0 +1,23 @@
+import { IRequest } from "itty-router";
+import { env } from "../typeDefinitions/default.types";
+import JSONResponse from "../utils/JsonResponse";
+import * as response from "../constants/responses";
+import { verifyAuthToken } from "../utils/verifyAuthToken";
+import { updateNickName } from "../utils/updateNickname";
+
+export async function changeNickname(request: IRequest, env: env) {
+  const authHeader = await request.headers.get("Authorization");
+
+  if (!authHeader) {
+    return new JSONResponse(response.BAD_SIGNATURE);
+  }
+
+  try {
+    await verifyAuthToken(authHeader, env);
+    const { discordId, userName } = await request.json();
+    const res = await updateNickName(discordId, userName, env);
+    return new JSONResponse(res);
+  } catch {
+    return new JSONResponse(response.BAD_SIGNATURE);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,17 @@
 import { Router } from "itty-router";
 import { InteractionResponseType, InteractionType } from "discord-interactions";
-import jwt from "@tsndr/cloudflare-worker-jwt";
 import * as response from "./constants/responses";
 import { baseHandler } from "./controllers/baseHandler";
 import { env } from "./typeDefinitions/default.types";
 import { discordMessageRequest } from "./typeDefinitions/discordMessage.types";
 import JSONResponse from "./utils/JsonResponse";
 import { verifyBot } from "./utils/verifyBot";
-import { updateNickName } from "./utils/updateNickname";
 import {
   addGroupRoleHandler,
   createGuildRoleHandler,
 } from "./controllers/guildRoleHandler";
 import { getMembersInServerHandler } from "./controllers/getMembersInServer";
+import { changeNickname } from "./controllers/changeNickname";
 
 const router = Router();
 
@@ -22,18 +21,8 @@ router.get("/", async () => {
   });
 });
 
-router.patch("/", async (request, env) => {
-  const req = await request.json();
-  const authorization = await request.headers
-    .get("Authorization")
-    .split(" ")[1];
-  if (await jwt.verify(authorization, env.BOT_PRIVATE_KEY)) {
-    const discord_id = req.discordId;
-    const nickname = req.username;
-    const res = await updateNickName(discord_id, nickname, env);
-    return new JSONResponse(res);
-  } else return new JSONResponse(response.BAD_SIGNATURE);
-});
+router.patch("/change-nickname", changeNickname);
+
 router.put("/roles/create", createGuildRoleHandler);
 
 router.put("/roles/add", addGroupRoleHandler);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Router } from "itty-router";
 import { InteractionResponseType, InteractionType } from "discord-interactions";
+import jwt from "@tsndr/cloudflare-worker-jwt";
 import * as response from "./constants/responses";
 import { baseHandler } from "./controllers/baseHandler";
 import { env } from "./typeDefinitions/default.types";
@@ -18,10 +19,15 @@ router.get("/", async () => {
 
 router.patch("/", async (request, env) => {
   const req = await request.json();
-  const discord_id = req.discordId;
-  const nickname = req.username;
-  const res = await updateNickName(discord_id, nickname, env);
-  return new JSONResponse(res);
+  const authorization = await request.headers
+    .get("Authorization")
+    .split(" ")[1];
+  if (await jwt.verify(authorization, env.BOT_PRIVATE_KEY)) {
+    const discord_id = req.discordId;
+    const nickname = req.username;
+    const res = await updateNickName(discord_id, nickname, env);
+    return new JSONResponse(res);
+  } else return new JSONResponse(response.BAD_SIGNATURE);
 });
 
 router.post("/", async (request, env) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { env } from "./typeDefinitions/default.types";
 import { discordMessageRequest } from "./typeDefinitions/discordMessage.types";
 import JSONResponse from "./utils/JsonResponse";
 import { verifyBot } from "./utils/verifyBot";
+import { updateNickName } from "./utils/updateNickname";
 
 const router = Router();
 
@@ -13,6 +14,14 @@ router.get("/", async () => {
   return new JSONResponse(response.STATUS_CHECK, {
     status: 200,
   });
+});
+
+router.patch("/", async (request, env) => {
+  const req = await request.json();
+  const discord_id = req.discordId;
+  const nickname = req.username;
+  const res = await updateNickName(discord_id, nickname, env);
+  return new JSONResponse(res);
 });
 
 router.post("/", async (request, env) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ router.get("/", async () => {
   });
 });
 
-router.patch("/name/update", changeNickname);
+router.patch("/guild/member", changeNickname);
 
 router.put("/roles/create", createGuildRoleHandler);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ router.get("/", async () => {
   });
 });
 
-router.patch("/change-nickname", changeNickname);
+router.patch("/name/update", changeNickname);
 
 router.put("/roles/create", createGuildRoleHandler);
 

--- a/src/utils/updateNickname.ts
+++ b/src/utils/updateNickname.ts
@@ -22,7 +22,6 @@ export async function updateNickName(
       return NAME_CHANGED;
     }
   } catch (error) {
-    console.log(error);
     return INTERNAL_SERVER_ERROR;
   }
 }

--- a/src/utils/updateNickname.ts
+++ b/src/utils/updateNickname.ts
@@ -21,7 +21,6 @@ export async function updateNickName(
     if (nameChangeResponse.ok) {
       return await nameChangeResponse.json();
     } else {
-      console.log(nameChangeResponse.json());
       return INTERNAL_SERVER_ERROR;
     }
   } catch (error) {

--- a/src/utils/updateNickname.ts
+++ b/src/utils/updateNickname.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_SERVER_ERROR } from "../constants/responses";
+import { INTERNAL_SERVER_ERROR, NAME_CHANGED } from "../constants/responses";
 import { DISCORD_BASE_URL } from "../constants/urls";
 import { env } from "../typeDefinitions/default.types";
 
@@ -19,7 +19,7 @@ export async function updateNickName(
       body: JSON.stringify(data),
     });
     if (nameChangeResponse.ok) {
-      return await nameChangeResponse.json();
+      return NAME_CHANGED;
     } else {
       return INTERNAL_SERVER_ERROR;
     }

--- a/src/utils/updateNickname.ts
+++ b/src/utils/updateNickname.ts
@@ -20,8 +20,6 @@ export async function updateNickName(
     });
     if (nameChangeResponse.ok) {
       return NAME_CHANGED;
-    } else {
-      return INTERNAL_SERVER_ERROR;
     }
   } catch (error) {
     console.log(error);

--- a/tests/unit/utils/updateNickname.test.ts
+++ b/tests/unit/utils/updateNickname.test.ts
@@ -1,0 +1,44 @@
+import { NAME_CHANGED } from "../../../src/constants/responses";
+import { DISCORD_BASE_URL } from "../../../src/constants/urls";
+import JSONResponse from "../../../src/utils/JsonResponse";
+import { updateNickName } from "../../../src/utils/updateNickname";
+
+describe("Update nickname", () => {
+  const mockEnv = {
+    BOT_PUBLIC_KEY: "xyz",
+    DISCORD_GUILD_ID: "123",
+    DISCORD_TOKEN: "abc",
+  };
+
+  const mockData = { discordId: "12345678910111213", nickname: "jhon" };
+
+  test("updatenickname fetch is called with expected parameters", async () => {
+    const data = { nick: mockData.nickname };
+
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation(() =>
+        Promise.resolve(new JSONResponse(NAME_CHANGED))
+      );
+
+    const response = await updateNickName(
+      mockData.discordId,
+      mockData.nickname,
+      mockEnv
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${DISCORD_BASE_URL}/guilds/${mockEnv.DISCORD_GUILD_ID}/members/${mockData.discordId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bot ${mockEnv.DISCORD_TOKEN}`,
+        },
+        body: JSON.stringify(data),
+      }
+    );
+
+    expect(response).toEqual(NAME_CHANGED);
+  });
+});

--- a/tests/unit/utils/updateNickname.test.ts
+++ b/tests/unit/utils/updateNickname.test.ts
@@ -1,4 +1,7 @@
-import { NAME_CHANGED } from "../../../src/constants/responses";
+import {
+  INTERNAL_SERVER_ERROR,
+  NAME_CHANGED,
+} from "../../../src/constants/responses";
 import { DISCORD_BASE_URL } from "../../../src/constants/urls";
 import JSONResponse from "../../../src/utils/JsonResponse";
 import { updateNickName } from "../../../src/utils/updateNickname";
@@ -40,5 +43,29 @@ describe("Update nickname", () => {
     );
 
     expect(response).toEqual(NAME_CHANGED);
+  });
+
+  test("Return Internal server error for improper body", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockRejectedValue(() =>
+        Promise.resolve(new JSONResponse({ INTERNAL_SERVER_ERROR }))
+      );
+
+    const response = await updateNickName(mockData.discordId, "", mockEnv);
+
+    expect(response).toEqual(INTERNAL_SERVER_ERROR);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${DISCORD_BASE_URL}/guilds/${mockEnv.DISCORD_GUILD_ID}/members/${mockData.discordId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bot ${mockEnv.DISCORD_TOKEN}`,
+        },
+        body: JSON.stringify({ nick: "" }),
+      }
+    );
   });
 });


### PR DESCRIPTION
create an endpoint that when hit changes the user's server nickname as per the RDS backend.

endpoint Method: `PATCH`
Headers: `JWT` signed with `BOT_PUBLIC_KEY` stored in the RDS backend
body: 
```json
{
    id: <Discord id of the user>,
    username: <RDS Username>
}
```
endpoint URL: `Cloudflare handler link`
path: `/name/update`

When the endpoint is hit with the above-mentioned attributes the server nickname of the user will be changed to the username passed in the request body.

The authorization header includes jwt which is verified to check if the request is from valid source.

Edge Cases
- User may change their server names after the patch request
    - `solution`: stop allowing users to change nicknames in the server. Make sure only bot is able to do that.