### PR TITLE
add account-id

### DIFF
--- a/.github/workflows/register-commands-production.yaml
+++ b/.github/workflows/register-commands-production.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{secrets.CLOUDFLARE_API_TOKEN}}
+          accountId: ${{secrets.CLOUDFLARE_ACCOUNT_ID}}
           secrets: |
             DISCORD_PUBLIC_KEY
             DISCORD_TOKEN

--- a/.github/workflows/register-commands-staging.yaml
+++ b/.github/workflows/register-commands-staging.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{secrets.CLOUDFLARE_API_TOKEN}}
+          accountId: ${{secrets.CLOUDFLARE_ACCOUNT_ID}}
           secrets: |
             DISCORD_PUBLIC_KEY
             DISCORD_TOKEN


### PR DESCRIPTION
Please add the cloudflare account id before merging

Add CF account id to GitHub workflows.
Reason, We want to give minimum permission to cloudflare workers