### PR TITLE
create GET /discord-members API

### DIFF
--- a/API_CONTRACTS.md
+++ b/API_CONTRACTS.md
@@ -1,0 +1,25 @@
+```
+{
+        "avatar": null,
+        "communication_disabled_until": null,
+        "flags": 0,
+        "is_pending": false,
+        "joined_at": "2023-04-28T12:24:05.465000+00:00",
+        "nick": null,
+        "pending": false,
+        "premium_since": null,
+        "roles": [],
+        "user": {
+            "id": "528222297970966539",
+            "username": "DeipayanDash",
+            "global_name": null,
+            "display_name": null,
+            "avatar": "90f862f124225c191e089134f1ef9991",
+            "discriminator": "6818",
+            "public_flags": 64,
+            "avatar_decoration": null
+        },
+        "mute": false,
+        "deaf": false
+    },
+```

--- a/src/controllers/getMembersInServer.ts
+++ b/src/controllers/getMembersInServer.ts
@@ -1,0 +1,33 @@
+import jwt from "@tsndr/cloudflare-worker-jwt";
+import { IRequest } from "itty-router";
+import * as response from "../constants/responses";
+import { env } from "../typeDefinitions/default.types";
+import { DISCORD_BASE_URL } from "../constants/urls";
+import JSONResponse from "../utils/JsonResponse";
+
+export const getMembersInServer = async (request: IRequest, env: env) => {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader) {
+    return new JSONResponse(response.BAD_SIGNATURE);
+  }
+  const authToken = authHeader.split(" ")[1];
+  try {
+    await jwt.verify(authToken, env.BOT_PUBLIC_KEY, { algorithm: "RS256" });
+
+    const MEMBERS_URL = `${DISCORD_BASE_URL}/guilds/${env.DISCORD_GUILD_ID}/members?limit=100`;
+    const response = await fetch(MEMBERS_URL, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bot ${env.DISCORD_TOKEN}`,
+      },
+    });
+    const users = await response.json();
+    console.log(users);
+
+    return new JSONResponse(users);
+  } catch (err) {
+    console.error(err);
+    return new JSONResponse(response.BAD_SIGNATURE);
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { env } from "./typeDefinitions/default.types";
 import { discordMessageRequest } from "./typeDefinitions/discordMessage.types";
 import JSONResponse from "./utils/JsonResponse";
 import { verifyBot } from "./utils/verifyBot";
+import { getMembersInServer } from "./controllers/getMembersInServer";
 
 const router = Router();
 
@@ -14,6 +15,8 @@ router.get("/", async () => {
     status: 200,
   });
 });
+
+router.get("/discord-members", getMembersInServer);
 
 router.post("/", async (request, env) => {
   const message: discordMessageRequest = await request.json();

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "discord-slash-commands"
+name = "hello-bot"
 main = "src/index.ts"
 compatibility_date = "2023-01-13"
 node_compat = true


### PR DESCRIPTION
### Changes Made
Create a GET` /discord-members` API that calls `/members?limit=1000` (limit: 0-1000, default:1000 ) which returns a list of discord members' data.
**Additional Permission Required:** GUILD_MEMBERS [Privileged Intent](https://discord.com/developers/docs/topics/gateway#privileged-intents)
