### PR TITLE
[Feature] Add APIs for fetching role information

### DIFF
--- a/src/constants/responses.ts
+++ b/src/constants/responses.ts
@@ -27,3 +27,10 @@ export const ROLE_ADDED = "Role added successfully";
 export const NAME_CHANGED = "User nickname changed successfully";
 
 export const ROLE_REMOVED = "Role Removed successfully";
+
+export const ROLE_FETCH_FAILED_MESSAGE =
+  "Oops! We are experiencing an issue fetching roles.";
+
+export const ROLE_FETCH_FAILED_ERROR = {
+  error: ROLE_FETCH_FAILED_MESSAGE,
+};

--- a/src/constants/responses.ts
+++ b/src/constants/responses.ts
@@ -28,9 +28,5 @@ export const NAME_CHANGED = "User nickname changed successfully";
 
 export const ROLE_REMOVED = "Role Removed successfully";
 
-export const ROLE_FETCH_FAILED_MESSAGE =
+export const ROLE_FETCH_FAILED =
   "Oops! We are experiencing an issue fetching roles.";
-
-export const ROLE_FETCH_FAILED_ERROR = {
-  error: ROLE_FETCH_FAILED_MESSAGE,
-};

--- a/src/constants/responses.ts
+++ b/src/constants/responses.ts
@@ -30,3 +30,7 @@ export const ROLE_REMOVED = "Role Removed successfully";
 
 export const ROLE_FETCH_FAILED =
   "Oops! We are experiencing an issue fetching roles.";
+
+export const BAD_REQUEST = {
+  error: "Oops! This is not a proper request.",
+};

--- a/src/controllers/guildRoleHandler.ts
+++ b/src/controllers/guildRoleHandler.ts
@@ -79,24 +79,16 @@ export async function getGuildRolesHandler(request: IRequest, env: env) {
   try {
     await verifyAuthToken(authHeader, env);
     const roles = await getGuildRoles(env);
-    if (!roles) {
-      throw new Error(response.ROLE_FETCH_FAILED);
-    }
     return new JSONResponse({ roles });
   } catch (err: any) {
-    if (err.message === response.ROLE_FETCH_FAILED) {
-      return new JSONResponse(
-        { error: response.ROLE_FETCH_FAILED },
-        {
-          status: 500,
-          headers: {
-            "content-type": "application/json;charset=UTF-8",
-          },
-        }
-      );
-    }
+    const error =
+      err?.message === response.ROLE_FETCH_FAILED
+        ? response.ROLE_FETCH_FAILED
+        : response.INTERNAL_SERVER_ERROR;
     return new JSONResponse(
-      { error: response.INTERNAL_SERVER_ERROR },
+      {
+        error,
+      },
       {
         status: 500,
         headers: {
@@ -134,19 +126,12 @@ export async function getGuildRoleByRoleNameHandler(
     }
     return new JSONResponse(role);
   } catch (err: any) {
-    if (err.message === response.ROLE_FETCH_FAILED) {
-      return new JSONResponse(
-        { error: response.ROLE_FETCH_FAILED },
-        {
-          status: 500,
-          headers: {
-            "content-type": "application/json;charset=UTF-8",
-          },
-        }
-      );
-    }
+    const error =
+      err?.message === response.ROLE_FETCH_FAILED
+        ? response.ROLE_FETCH_FAILED
+        : response.INTERNAL_SERVER_ERROR;
     return new JSONResponse(
-      { error: response.INTERNAL_SERVER_ERROR },
+      { error },
       {
         status: 500,
         headers: {

--- a/src/controllers/guildRoleHandler.ts
+++ b/src/controllers/guildRoleHandler.ts
@@ -79,6 +79,9 @@ export async function getGuildRolesHandler(request: IRequest, env: env) {
   try {
     await verifyAuthToken(authHeader, env);
     const roles = await getGuildRoles(env);
+    if (!roles) {
+      throw new Error(response.ROLE_FETCH_FAILED);
+    }
     return new JSONResponse({ roles });
   } catch (err: any) {
     if (err.message === response.ROLE_FETCH_FAILED) {

--- a/src/controllers/guildRoleHandler.ts
+++ b/src/controllers/guildRoleHandler.ts
@@ -81,10 +81,13 @@ export async function getGuildRolesHandler(request: IRequest, env: env) {
     const roles = await getGuildRoles(env);
     return new JSONResponse({ roles });
   } catch (err: any) {
-    if (err.message === response.ROLE_FETCH_FAILED_MESSAGE) {
-      return new JSONResponse(response.ROLE_FETCH_FAILED_ERROR, {
-        status: 500,
-      });
+    if (err.message === response.ROLE_FETCH_FAILED) {
+      return new JSONResponse(
+        { error: response.ROLE_FETCH_FAILED },
+        {
+          status: 500,
+        }
+      );
     }
     return new JSONResponse(response.INTERNAL_SERVER_ERROR, { status: 500 });
   }
@@ -112,10 +115,13 @@ export async function getGuildRoleByRoleNameHandler(
     }
     return new JSONResponse(role);
   } catch (err: any) {
-    if (err.message === response.ROLE_FETCH_FAILED_MESSAGE) {
-      return new JSONResponse(response.ROLE_FETCH_FAILED_ERROR, {
-        status: 500,
-      });
+    if (err.message === response.ROLE_FETCH_FAILED) {
+      return new JSONResponse(
+        { error: response.ROLE_FETCH_FAILED },
+        {
+          status: 500,
+        }
+      );
     }
     return new JSONResponse(response.INTERNAL_SERVER_ERROR, { status: 500 });
   }

--- a/src/controllers/guildRoleHandler.ts
+++ b/src/controllers/guildRoleHandler.ts
@@ -86,10 +86,21 @@ export async function getGuildRolesHandler(request: IRequest, env: env) {
         { error: response.ROLE_FETCH_FAILED },
         {
           status: 500,
+          headers: {
+            "content-type": "application/json;charset=UTF-8",
+          },
         }
       );
     }
-    return new JSONResponse(response.INTERNAL_SERVER_ERROR, { status: 500 });
+    return new JSONResponse(
+      { error: response.INTERNAL_SERVER_ERROR },
+      {
+        status: 500,
+        headers: {
+          "content-type": "application/json;charset=UTF-8",
+        },
+      }
+    );
   }
 }
 
@@ -111,7 +122,12 @@ export async function getGuildRoleByRoleNameHandler(
     await verifyAuthToken(authHeader, env);
     const role = await getGuildRoleByName(roleName, env);
     if (!role) {
-      return new JSONResponse(response.NOT_FOUND, { status: 404 });
+      return new JSONResponse(response.NOT_FOUND, {
+        status: 404,
+        headers: {
+          "content-type": "application/json;charset=UTF-8",
+        },
+      });
     }
     return new JSONResponse(role);
   } catch (err: any) {
@@ -120,9 +136,20 @@ export async function getGuildRoleByRoleNameHandler(
         { error: response.ROLE_FETCH_FAILED },
         {
           status: 500,
+          headers: {
+            "content-type": "application/json;charset=UTF-8",
+          },
         }
       );
     }
-    return new JSONResponse(response.INTERNAL_SERVER_ERROR, { status: 500 });
+    return new JSONResponse(
+      { error: response.INTERNAL_SERVER_ERROR },
+      {
+        status: 500,
+        headers: {
+          "content-type": "application/json;charset=UTF-8",
+        },
+      }
+    );
   }
 }

--- a/src/controllers/guildRoleHandler.ts
+++ b/src/controllers/guildRoleHandler.ts
@@ -111,7 +111,7 @@ export async function getGuildRoleByRoleNameHandler(
   }
 
   if (!roleName) {
-    return new JSONResponse(response.NOT_FOUND, { status: 404 });
+    return new JSONResponse(response.BAD_REQUEST, { status: 404 });
   }
   try {
     await verifyAuthToken(authHeader, env);

--- a/src/controllers/guildRoleHandler.ts
+++ b/src/controllers/guildRoleHandler.ts
@@ -68,3 +68,15 @@ export async function removeGuildRoleHandler(request: IRequest, env: env) {
     });
   }
 }
+export async function getGuildRolesHandler(request: IRequest, env: env) {
+  // To be implemented
+  return new JSONResponse(response.NOT_FOUND);
+}
+
+export async function getGuildRoleByRoleNameHandler(
+  request: IRequest,
+  env: env
+) {
+  // To be implemented
+  return new JSONResponse(response.NOT_FOUND);
+}

--- a/src/controllers/guildRoleHandler.ts
+++ b/src/controllers/guildRoleHandler.ts
@@ -6,6 +6,8 @@ import {
   addGroupRole,
   createGuildRole,
   removeGuildRole,
+  getGuildRoleByName,
+  getGuildRoles,
 } from "../utils/guildRole";
 import {
   createNewRole,
@@ -69,14 +71,52 @@ export async function removeGuildRoleHandler(request: IRequest, env: env) {
   }
 }
 export async function getGuildRolesHandler(request: IRequest, env: env) {
-  // To be implemented
-  return new JSONResponse(response.NOT_FOUND);
+  const authHeader = request.headers.get("Authorization");
+
+  if (!authHeader) {
+    return new JSONResponse(response.BAD_SIGNATURE, { status: 401 });
+  }
+  try {
+    await verifyAuthToken(authHeader, env);
+    const roles = await getGuildRoles(env);
+    return new JSONResponse({ roles });
+  } catch (err: any) {
+    if (err.message === response.ROLE_FETCH_FAILED_MESSAGE) {
+      return new JSONResponse(response.ROLE_FETCH_FAILED_ERROR, {
+        status: 500,
+      });
+    }
+    return new JSONResponse(response.INTERNAL_SERVER_ERROR, { status: 500 });
+  }
 }
 
 export async function getGuildRoleByRoleNameHandler(
   request: IRequest,
   env: env
 ) {
-  // To be implemented
-  return new JSONResponse(response.NOT_FOUND);
+  const authHeader = request.headers.get("Authorization");
+  const roleName = decodeURI(request.params?.roleName ?? "");
+
+  if (!authHeader) {
+    return new JSONResponse(response.BAD_SIGNATURE, { status: 401 });
+  }
+
+  if (!roleName) {
+    return new JSONResponse(response.NOT_FOUND, { status: 404 });
+  }
+  try {
+    await verifyAuthToken(authHeader, env);
+    const role = await getGuildRoleByName(roleName, env);
+    if (!role) {
+      return new JSONResponse(response.NOT_FOUND, { status: 404 });
+    }
+    return new JSONResponse(role);
+  } catch (err: any) {
+    if (err.message === response.ROLE_FETCH_FAILED_MESSAGE) {
+      return new JSONResponse(response.ROLE_FETCH_FAILED_ERROR, {
+        status: 500,
+      });
+    }
+    return new JSONResponse(response.INTERNAL_SERVER_ERROR, { status: 500 });
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   addGroupRoleHandler,
   createGuildRoleHandler,
   removeGuildRoleHandler,
+  getGuildRoleByRoleNameHandler,
   getGuildRolesHandler,
 } from "./controllers/guildRoleHandler";
 import { getMembersInServerHandler } from "./controllers/getMembersInServer";
@@ -31,7 +32,10 @@ router.put("/roles/create", createGuildRoleHandler);
 router.put("/roles/add", addGroupRoleHandler);
 
 router.delete("/roles", removeGuildRoleHandler);
+
 router.get("/roles", getGuildRolesHandler);
+
+router.get("/roles/:roleName", getGuildRoleByRoleNameHandler);
 
 router.get("/discord-members", getMembersInServerHandler);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   addGroupRoleHandler,
   createGuildRoleHandler,
   removeGuildRoleHandler,
+  getGuildRolesHandler,
 } from "./controllers/guildRoleHandler";
 import { getMembersInServerHandler } from "./controllers/getMembersInServer";
 import { changeNickname } from "./controllers/changeNickname";
@@ -30,6 +31,7 @@ router.put("/roles/create", createGuildRoleHandler);
 router.put("/roles/add", addGroupRoleHandler);
 
 router.delete("/roles", removeGuildRoleHandler);
+router.get("/roles", getGuildRolesHandler);
 
 router.get("/discord-members", getMembersInServerHandler);
 

--- a/src/typeDefinitions/role.types.d.ts
+++ b/src/typeDefinitions/role.types.d.ts
@@ -1,0 +1,4 @@
+export type GuildRole = {
+  id: string;
+  name: string;
+};

--- a/src/typeDefinitions/role.types.d.ts
+++ b/src/typeDefinitions/role.types.d.ts
@@ -2,3 +2,19 @@ export type GuildRole = {
   id: string;
   name: string;
 };
+
+export type GuildDetails = {
+  // This type defines the partial guild details response that we get from discord
+  id: string;
+  name: string;
+  roles: Array<{
+    id: string;
+    name: string;
+    permissions: string;
+    position: number;
+    color: number;
+    hoist: boolean;
+    managed: boolean;
+    mentionable: boolean;
+  }>;
+};

--- a/src/typeDefinitions/role.types.d.ts
+++ b/src/typeDefinitions/role.types.d.ts
@@ -1,20 +1,12 @@
 export type GuildRole = {
   id: string;
   name: string;
+  color: string;
+  hoist: boolean;
+  icon?: string;
+  position?: integer;
+  managed?: boolean;
+  mentionable?: boolean;
 };
 
-export type GuildDetails = {
-  // This type defines the partial guild details response that we get from discord
-  id: string;
-  name: string;
-  roles: Array<{
-    id: string;
-    name: string;
-    permissions: string;
-    position: number;
-    color: number;
-    hoist: boolean;
-    managed: boolean;
-    mentionable: boolean;
-  }>;
-};
+export type Role = Pick<GuildRole, "id" | "name">;

--- a/src/utils/guildRole.ts
+++ b/src/utils/guildRole.ts
@@ -11,7 +11,7 @@ import {
   guildRoleResponse,
   memberGroupRole,
 } from "../typeDefinitions/discordMessage.types";
-import { GuildDetails, GuildRole } from "../typeDefinitions/role.types";
+import { GuildRole, Role } from "../typeDefinitions/role.types";
 
 export async function createGuildRole(
   body: createNewRole,
@@ -87,11 +87,11 @@ export async function removeGuildRole(details: memberGroupRole, env: env) {
   }
 }
 
-export async function getGuildRoles(env: env): Promise<Array<GuildRole>> {
-  const guildDetailsUrl = `${DISCORD_BASE_URL}/guilds/${env.DISCORD_GUILD_ID}`;
+export async function getGuildRoles(env: env): Promise<Array<Role>> {
+  const guildRolesUrl = `${DISCORD_BASE_URL}/guilds/${env.DISCORD_GUILD_ID}/roles`;
 
   try {
-    const response = await fetch(guildDetailsUrl, {
+    const response = await fetch(guildRolesUrl, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -103,9 +103,9 @@ export async function getGuildRoles(env: env): Promise<Array<GuildRole>> {
       throw new Error(ROLE_FETCH_FAILED);
     }
 
-    const guildDetails: GuildDetails = await response.json();
+    const guildRoles: Array<GuildRole> = await response.json();
 
-    return guildDetails.roles.map((role) => ({
+    return guildRoles.map((role) => ({
       id: role.id,
       name: role.name,
     }));
@@ -117,7 +117,7 @@ export async function getGuildRoles(env: env): Promise<Array<GuildRole>> {
 export async function getGuildRoleByName(
   roleName: string,
   env: env
-): Promise<GuildRole | undefined> {
+): Promise<Role | undefined> {
   const roles = await getGuildRoles(env);
   return roles?.find((role) => role.name === roleName);
 }

--- a/src/utils/guildRole.ts
+++ b/src/utils/guildRole.ts
@@ -2,7 +2,7 @@ import {
   INTERNAL_SERVER_ERROR,
   ROLE_ADDED,
   ROLE_REMOVED,
-  ROLE_FETCH_FAILED_MESSAGE,
+  ROLE_FETCH_FAILED,
 } from "../constants/responses";
 import { DISCORD_BASE_URL } from "../constants/urls";
 import { env } from "../typeDefinitions/default.types";
@@ -99,7 +99,7 @@ export async function getGuildRoles(env: env): Promise<Array<GuildRole>> {
   });
 
   if (!response.ok) {
-    throw new Error(ROLE_FETCH_FAILED_MESSAGE);
+    throw new Error(ROLE_FETCH_FAILED);
   }
 
   const guildDetails: GuildDetails = await response.json();

--- a/src/utils/guildRole.ts
+++ b/src/utils/guildRole.ts
@@ -1,6 +1,7 @@
 import {
   INTERNAL_SERVER_ERROR,
   ROLE_ADDED,
+  ROLE_FETCH_FAILED,
   ROLE_REMOVED,
 } from "../constants/responses";
 import { DISCORD_BASE_URL } from "../constants/urls";
@@ -86,9 +87,7 @@ export async function removeGuildRole(details: memberGroupRole, env: env) {
   }
 }
 
-export async function getGuildRoles(
-  env: env
-): Promise<Array<GuildRole> | undefined> {
+export async function getGuildRoles(env: env): Promise<Array<GuildRole>> {
   const guildDetailsUrl = `${DISCORD_BASE_URL}/guilds/${env.DISCORD_GUILD_ID}`;
 
   try {
@@ -101,7 +100,7 @@ export async function getGuildRoles(
     });
 
     if (!response.ok) {
-      return undefined;
+      throw new Error(ROLE_FETCH_FAILED);
     }
 
     const guildDetails: GuildDetails = await response.json();
@@ -111,7 +110,7 @@ export async function getGuildRoles(
       name: role.name,
     }));
   } catch (err) {
-    return undefined;
+    throw new Error(ROLE_FETCH_FAILED);
   }
 }
 

--- a/src/utils/guildRole.ts
+++ b/src/utils/guildRole.ts
@@ -10,6 +10,7 @@ import {
   guildRoleResponse,
   memberGroupRole,
 } from "../typeDefinitions/discordMessage.types";
+import { GuildRole } from "../typeDefinitions/role.types";
 
 export async function createGuildRole(
   body: createNewRole,
@@ -83,4 +84,19 @@ export async function removeGuildRole(details: memberGroupRole, env: env) {
   } catch (err) {
     return INTERNAL_SERVER_ERROR;
   }
+}
+
+
+export async function getGuildRoles(env: env): Promise<Array<GuildRole>> {
+  return [];
+}
+
+export async function getGuildRoleByName(
+  roleName: string,
+  env: env
+): Promise<GuildRole> {
+  return {
+    id: "dummy-id",
+    name: "dummy-name",
+  };
 }

--- a/tests/fixtures/fixture.ts
+++ b/tests/fixtures/fixture.ts
@@ -135,9 +135,3 @@ export const rolesMock = [
     mentionable: true,
   },
 ];
-
-export const guildDetailsMock = {
-  id: "123434232324242424",
-  name: "test server",
-  roles: rolesMock,
-};

--- a/tests/fixtures/fixture.ts
+++ b/tests/fixtures/fixture.ts
@@ -112,3 +112,30 @@ export const generateDummyRequestObject = ({
     headers: new Map(Object.entries(headers ?? {})),
   };
 };
+
+export const guildDetailsMock = {
+  id: "123434232324242424",
+  name: "test server",
+  roles: [
+    {
+      id: "1234567889",
+      name: "@everyone",
+      permissions: "",
+      position: 2,
+      color: 2,
+      hoist: true,
+      managed: true,
+      mentionable: true,
+    },
+    {
+      id: "12344567",
+      name: "bot one",
+      permissions: "",
+      position: 2,
+      color: 2,
+      hoist: true,
+      managed: true,
+      mentionable: true,
+    },
+  ],
+};

--- a/tests/fixtures/fixture.ts
+++ b/tests/fixtures/fixture.ts
@@ -113,29 +113,31 @@ export const generateDummyRequestObject = ({
   };
 };
 
+export const rolesMock = [
+  {
+    id: "1234567889",
+    name: "@everyone",
+    permissions: "",
+    position: 2,
+    color: 2,
+    hoist: true,
+    managed: true,
+    mentionable: true,
+  },
+  {
+    id: "12344567",
+    name: "bot one",
+    permissions: "",
+    position: 2,
+    color: 2,
+    hoist: true,
+    managed: true,
+    mentionable: true,
+  },
+];
+
 export const guildDetailsMock = {
   id: "123434232324242424",
   name: "test server",
-  roles: [
-    {
-      id: "1234567889",
-      name: "@everyone",
-      permissions: "",
-      position: 2,
-      color: 2,
-      hoist: true,
-      managed: true,
-      mentionable: true,
-    },
-    {
-      id: "12344567",
-      name: "bot one",
-      permissions: "",
-      position: 2,
-      color: 2,
-      hoist: true,
-      managed: true,
-      mentionable: true,
-    },
-  ],
+  roles: rolesMock,
 };

--- a/tests/fixtures/fixture.ts
+++ b/tests/fixtures/fixture.ts
@@ -1,3 +1,4 @@
+import { IRequest } from "itty-router";
 import {
   createNewRole,
   discordMessageRequest,
@@ -94,4 +95,20 @@ export const onlyRoleToBeTagged = {
     type: 8,
     value: "1118201414078976192",
   },
+};
+
+export const generateDummyRequestObject = ({
+  url,
+  method,
+  params,
+  query,
+  headers, // Object of key value pair
+}: Partial<IRequest>): IRequest => {
+  return {
+    method: method ?? "GET",
+    url: url ?? "/roles",
+    params: params ?? {},
+    query: query ?? {},
+    headers: new Map(Object.entries(headers ?? {})),
+  };
 };

--- a/tests/unit/handlers/guildRoleHandler.test.ts
+++ b/tests/unit/handlers/guildRoleHandler.test.ts
@@ -1,0 +1,119 @@
+import {
+  getGuildRoleByRoleNameHandler,
+  getGuildRolesHandler,
+} from "../../../src/controllers/guildRoleHandler";
+import { GuildRole } from "../../../src/typeDefinitions/role.types";
+import JSONResponse from "../../../src/utils/JsonResponse";
+import { generateDummyRequestObject } from "../../fixtures/fixture";
+import * as responseConstants from "../../../src/constants/responses";
+
+jest.mock("../../../src/utils/verifyAuthToken", () => ({
+  verifyAuthToken: jest.fn().mockReturnValue(true),
+}));
+
+describe.skip("get roles", () => {
+  it("should return a instance of JSONResponse", async () => {
+    const mockRequest = generateDummyRequestObject({ url: "/roles" });
+    const response = await getGuildRolesHandler(mockRequest, {});
+    expect(response).toBeInstanceOf(JSONResponse);
+  });
+
+  it("should return Bad Signature object if no auth headers provided", async () => {
+    const mockRequest = generateDummyRequestObject({ url: "/roles" });
+    const response: JSONResponse = await getGuildRolesHandler(mockRequest, {});
+    const jsonResponse: { error: string } = await response.json();
+    expect(response.status).toBe(401);
+    expect(jsonResponse.error).toBe(responseConstants.BAD_SIGNATURE);
+  });
+
+  it("should return empty array if there is no roles in guild", async () => {
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles",
+      headers: { Authorization: "Bearer testtoken" },
+    });
+
+    const response: JSONResponse = await getGuildRolesHandler(mockRequest, {});
+    const jsonRespose: { roles: Array<{ id: string; name: string }> } =
+      await response.json();
+    expect(response.status).toBe(200);
+    expect(Array.isArray(jsonRespose.roles)).toBeTruthy();
+    expect(jsonRespose.roles.length).toBe(0);
+  });
+
+  it("should return array of id and name of roles present in guild", async () => {
+    const expectedResponse = [
+      {
+        id: "role_id_one",
+        name: "role_name_one",
+      },
+      {
+        id: "role_id_two",
+        name: "role_name_two",
+      },
+    ];
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles",
+      headers: { Authorization: "Bearer testtoken" },
+    });
+
+    const response: JSONResponse = await getGuildRolesHandler(mockRequest, {});
+    const jsonRespose: { roles: Array<GuildRole> } = await response.json();
+    expect(response.status).toBe(200);
+    expect(Array.isArray(jsonRespose.roles)).toBeTruthy();
+    expect(jsonRespose.roles).toEqual(expectedResponse);
+  });
+});
+
+describe.skip("get role by role name", () => {
+  it("should return a instance of JSONResponse", async () => {
+    const mockRequest = generateDummyRequestObject({ url: "/roles/everyone" });
+    const response = await getGuildRoleByRoleNameHandler(mockRequest, {});
+    expect(response).toBeInstanceOf(JSONResponse);
+  });
+
+  it("should return Bad Signature object if no auth headers provided", async () => {
+    const mockRequest = generateDummyRequestObject({ url: "/roles/everyone" });
+    const response: JSONResponse = await getGuildRoleByRoleNameHandler(
+      mockRequest,
+      {}
+    );
+    const jsonResponse: { error: string } = await response.json();
+    expect(response.status).toBe(401);
+    expect(jsonResponse.error).toBe("🚫 Bad Request Signature");
+  });
+
+  it("should return not found object if there is no roles with given name in guild", async () => {
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles/everyone",
+      headers: { Authorization: "Bearer testtoken" },
+    });
+
+    const response: JSONResponse = await getGuildRoleByRoleNameHandler(
+      mockRequest,
+      {}
+    );
+    const jsonRespose: { error: string } = await response.json();
+    expect(response.status).toBe(404);
+    expect(jsonRespose.error).toBe(responseConstants.NOT_FOUND);
+  });
+
+  it("should return object of id and name corresponding to the role name recieved", async () => {
+    const expectedResponse = {
+      id: "role_id_one",
+      name: "everyone",
+    };
+
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles/everyone",
+      headers: { Authorization: "Bearer testtoken" },
+    });
+
+    const response: JSONResponse = await getGuildRoleByRoleNameHandler(
+      mockRequest,
+      {}
+    );
+    const jsonRespose: { roles: Array<GuildRole> } = await response.json();
+    expect(response.status).toBe(200);
+    expect(jsonRespose).toEqual(expectedResponse);
+  });
+});

--- a/tests/unit/handlers/guildRoleHandler.test.ts
+++ b/tests/unit/handlers/guildRoleHandler.test.ts
@@ -4,40 +4,86 @@ import {
 } from "../../../src/controllers/guildRoleHandler";
 import { GuildRole } from "../../../src/typeDefinitions/role.types";
 import JSONResponse from "../../../src/utils/JsonResponse";
-import { generateDummyRequestObject } from "../../fixtures/fixture";
+import { generateDummyRequestObject, guildEnv } from "../../fixtures/fixture";
 import * as responseConstants from "../../../src/constants/responses";
+import * as guildRoleUtils from "../../../src/utils/guildRole";
 
 jest.mock("../../../src/utils/verifyAuthToken", () => ({
   verifyAuthToken: jest.fn().mockReturnValue(true),
 }));
 
-describe.skip("get roles", () => {
+const getGuildRolesSpy = jest.spyOn(guildRoleUtils, "getGuildRoles");
+const getGuildRoleByNameSpy = jest.spyOn(guildRoleUtils, "getGuildRoleByName");
+
+describe("get roles", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
   it("should return a instance of JSONResponse", async () => {
     const mockRequest = generateDummyRequestObject({ url: "/roles" });
-    const response = await getGuildRolesHandler(mockRequest, {});
+    const response = await getGuildRolesHandler(mockRequest, guildEnv);
     expect(response).toBeInstanceOf(JSONResponse);
   });
 
   it("should return Bad Signature object if no auth headers provided", async () => {
     const mockRequest = generateDummyRequestObject({ url: "/roles" });
-    const response: JSONResponse = await getGuildRolesHandler(mockRequest, {});
+    const response: JSONResponse = await getGuildRolesHandler(
+      mockRequest,
+      guildEnv
+    );
     const jsonResponse: { error: string } = await response.json();
     expect(response.status).toBe(401);
-    expect(jsonResponse.error).toBe(responseConstants.BAD_SIGNATURE);
+    expect(jsonResponse).toEqual(responseConstants.BAD_SIGNATURE);
+  });
+
+  it("should return role fetch failed error response if it fails to fetch roles", async () => {
+    getGuildRolesSpy.mockRejectedValueOnce({
+      message: responseConstants.ROLE_FETCH_FAILED_MESSAGE,
+    });
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles",
+      headers: { Authorization: "Bearer testtoken" },
+    });
+    const response: JSONResponse = await getGuildRolesHandler(
+      mockRequest,
+      guildEnv
+    );
+    const jsonResponse = await response.json();
+    expect(response.status).toBe(500);
+    expect(jsonResponse).toEqual(responseConstants.ROLE_FETCH_FAILED_ERROR);
+  });
+
+  it("should return internal server error response if it fails for any other reason", async () => {
+    getGuildRolesSpy.mockRejectedValueOnce({});
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles",
+      headers: { Authorization: "Bearer testtoken" },
+    });
+    const response: JSONResponse = await getGuildRolesHandler(
+      mockRequest,
+      guildEnv
+    );
+    const jsonResponse = await response.json();
+    expect(response.status).toBe(500);
+    expect(jsonResponse).toBe(responseConstants.INTERNAL_SERVER_ERROR);
   });
 
   it("should return empty array if there is no roles in guild", async () => {
+    getGuildRolesSpy.mockResolvedValue([]);
     const mockRequest = generateDummyRequestObject({
       url: "/roles",
       headers: { Authorization: "Bearer testtoken" },
     });
 
-    const response: JSONResponse = await getGuildRolesHandler(mockRequest, {});
-    const jsonRespose: { roles: Array<{ id: string; name: string }> } =
+    const response: JSONResponse = await getGuildRolesHandler(
+      mockRequest,
+      guildEnv
+    );
+    const jsonResponse: { roles: Array<{ id: string; name: string }> } =
       await response.json();
     expect(response.status).toBe(200);
-    expect(Array.isArray(jsonRespose.roles)).toBeTruthy();
-    expect(jsonRespose.roles.length).toBe(0);
+    expect(Array.isArray(jsonResponse.roles)).toBeTruthy();
+    expect(jsonResponse.roles.length).toBe(0);
   });
 
   it("should return array of id and name of roles present in guild", async () => {
@@ -51,50 +97,136 @@ describe.skip("get roles", () => {
         name: "role_name_two",
       },
     ];
+    getGuildRolesSpy.mockResolvedValueOnce(expectedResponse);
+
     const mockRequest = generateDummyRequestObject({
       url: "/roles",
       headers: { Authorization: "Bearer testtoken" },
     });
 
-    const response: JSONResponse = await getGuildRolesHandler(mockRequest, {});
-    const jsonRespose: { roles: Array<GuildRole> } = await response.json();
+    const response: JSONResponse = await getGuildRolesHandler(
+      mockRequest,
+      guildEnv
+    );
+    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
     expect(response.status).toBe(200);
-    expect(Array.isArray(jsonRespose.roles)).toBeTruthy();
-    expect(jsonRespose.roles).toEqual(expectedResponse);
+    expect(Array.isArray(jsonResponse.roles)).toBeTruthy();
+    expect(jsonResponse.roles).toEqual(expectedResponse);
   });
 });
 
-describe.skip("get role by role name", () => {
+describe("get role by role name", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   it("should return a instance of JSONResponse", async () => {
-    const mockRequest = generateDummyRequestObject({ url: "/roles/everyone" });
-    const response = await getGuildRoleByRoleNameHandler(mockRequest, {});
+    getGuildRoleByNameSpy.mockResolvedValueOnce(undefined);
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles",
+      params: {
+        roleName: "everyone",
+      },
+      headers: { Authorization: "Bearer testtoken" },
+    });
+    const response = await getGuildRoleByRoleNameHandler(mockRequest, guildEnv);
     expect(response).toBeInstanceOf(JSONResponse);
   });
 
   it("should return Bad Signature object if no auth headers provided", async () => {
-    const mockRequest = generateDummyRequestObject({ url: "/roles/everyone" });
+    getGuildRoleByNameSpy.mockResolvedValueOnce(undefined);
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles",
+      params: {
+        roleName: "everyone",
+      },
+    });
     const response: JSONResponse = await getGuildRoleByRoleNameHandler(
       mockRequest,
-      {}
+      guildEnv
     );
     const jsonResponse: { error: string } = await response.json();
     expect(response.status).toBe(401);
-    expect(jsonResponse.error).toBe("🚫 Bad Request Signature");
+    expect(jsonResponse).toEqual(responseConstants.BAD_SIGNATURE);
+  });
+
+  it("should return Not Found error if no roleName is not provided", async () => {
+    getGuildRoleByNameSpy.mockResolvedValueOnce(undefined);
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles",
+      params: {},
+
+      headers: { Authorization: "Bearer testtoken" },
+    });
+    const response: JSONResponse = await getGuildRoleByRoleNameHandler(
+      mockRequest,
+      guildEnv
+    );
+    const jsonResponse: { error: string } = await response.json();
+    expect(response.status).toBe(404);
+    expect(jsonResponse).toEqual(responseConstants.NOT_FOUND);
   });
 
   it("should return not found object if there is no roles with given name in guild", async () => {
+    getGuildRoleByNameSpy.mockResolvedValueOnce(undefined);
+
     const mockRequest = generateDummyRequestObject({
-      url: "/roles/everyone",
+      url: "/roles",
+      params: {
+        roleName: "everyone",
+      },
       headers: { Authorization: "Bearer testtoken" },
     });
 
     const response: JSONResponse = await getGuildRoleByRoleNameHandler(
       mockRequest,
-      {}
+      guildEnv
     );
-    const jsonRespose: { error: string } = await response.json();
+    const jsonResponse: { error: string } = await response.json();
     expect(response.status).toBe(404);
-    expect(jsonRespose.error).toBe(responseConstants.NOT_FOUND);
+    expect(jsonResponse).toEqual(responseConstants.NOT_FOUND);
+  });
+
+  it("should return role fetch failed error if there was an error while fetching roles", async () => {
+    getGuildRoleByNameSpy.mockRejectedValueOnce({
+      message: responseConstants.ROLE_FETCH_FAILED_MESSAGE,
+    });
+
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles",
+      params: {
+        roleName: "everyone",
+      },
+      headers: { Authorization: "Bearer testtoken" },
+    });
+
+    const response: JSONResponse = await getGuildRoleByRoleNameHandler(
+      mockRequest,
+      guildEnv
+    );
+    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
+    expect(response.status).toBe(500);
+    expect(jsonResponse).toEqual(responseConstants.ROLE_FETCH_FAILED_ERROR);
+  });
+
+  it("should return internal server error if there was any other error", async () => {
+    getGuildRoleByNameSpy.mockRejectedValueOnce({});
+
+    const mockRequest = generateDummyRequestObject({
+      url: "/roles",
+      params: {
+        roleName: "everyone",
+      },
+      headers: { Authorization: "Bearer testtoken" },
+    });
+
+    const response: JSONResponse = await getGuildRoleByRoleNameHandler(
+      mockRequest,
+      guildEnv
+    );
+    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
+    expect(response.status).toBe(500);
+    expect(jsonResponse).toBe(responseConstants.INTERNAL_SERVER_ERROR);
   });
 
   it("should return object of id and name corresponding to the role name recieved", async () => {
@@ -103,17 +235,22 @@ describe.skip("get role by role name", () => {
       name: "everyone",
     };
 
+    getGuildRoleByNameSpy.mockResolvedValueOnce(expectedResponse);
+
     const mockRequest = generateDummyRequestObject({
-      url: "/roles/everyone",
+      url: "/roles",
+      params: {
+        roleName: "everyone",
+      },
       headers: { Authorization: "Bearer testtoken" },
     });
 
     const response: JSONResponse = await getGuildRoleByRoleNameHandler(
       mockRequest,
-      {}
+      guildEnv
     );
-    const jsonRespose: { roles: Array<GuildRole> } = await response.json();
+    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
     expect(response.status).toBe(200);
-    expect(jsonRespose).toEqual(expectedResponse);
+    expect(jsonResponse).toEqual(expectedResponse);
   });
 });

--- a/tests/unit/handlers/guildRoleHandler.test.ts
+++ b/tests/unit/handlers/guildRoleHandler.test.ts
@@ -4,7 +4,11 @@ import {
 } from "../../../src/controllers/guildRoleHandler";
 import { GuildRole } from "../../../src/typeDefinitions/role.types";
 import JSONResponse from "../../../src/utils/JsonResponse";
-import { generateDummyRequestObject, guildEnv } from "../../fixtures/fixture";
+import {
+  generateDummyRequestObject,
+  guildEnv,
+  rolesMock,
+} from "../../fixtures/fixture";
 import * as responseConstants from "../../../src/constants/responses";
 import * as guildRoleUtils from "../../../src/utils/guildRole";
 
@@ -83,24 +87,14 @@ describe("get roles", () => {
       mockRequest,
       guildEnv
     );
-    const jsonResponse: { roles: Array<{ id: string; name: string }> } =
-      await response.json();
+    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
     expect(response.status).toBe(200);
     expect(Array.isArray(jsonResponse.roles)).toBeTruthy();
     expect(jsonResponse.roles.length).toBe(0);
   });
 
   it("should return array of id and name of roles present in guild", async () => {
-    const expectedResponse = [
-      {
-        id: "role_id_one",
-        name: "role_name_one",
-      },
-      {
-        id: "role_id_two",
-        name: "role_name_two",
-      },
-    ];
+    const expectedResponse = rolesMock;
     getGuildRolesSpy.mockResolvedValueOnce(expectedResponse);
 
     const mockRequest = generateDummyRequestObject({
@@ -238,12 +232,7 @@ describe("get role by role name", () => {
   });
 
   it("should return object of id and name corresponding to the role name recieved", async () => {
-    const expectedResponse = {
-      id: "role_id_one",
-      name: "everyone",
-    };
-
-    getGuildRoleByNameSpy.mockResolvedValueOnce(expectedResponse);
+    getGuildRoleByNameSpy.mockResolvedValueOnce(rolesMock[0]);
 
     const mockRequest = generateDummyRequestObject({
       url: "/roles",
@@ -259,6 +248,6 @@ describe("get role by role name", () => {
     );
     const jsonResponse: { roles: Array<GuildRole> } = await response.json();
     expect(response.status).toBe(200);
-    expect(jsonResponse).toEqual(expectedResponse);
+    expect(jsonResponse).toEqual(rolesMock[0]);
   });
 });

--- a/tests/unit/handlers/guildRoleHandler.test.ts
+++ b/tests/unit/handlers/guildRoleHandler.test.ts
@@ -20,9 +20,6 @@ const getGuildRolesSpy = jest.spyOn(guildRoleUtils, "getGuildRoles");
 const getGuildRoleByNameSpy = jest.spyOn(guildRoleUtils, "getGuildRoleByName");
 
 describe("get roles", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
   it("should return a instance of JSONResponse", async () => {
     const mockRequest = generateDummyRequestObject({ url: "/roles" });
     const response = await getGuildRolesHandler(mockRequest, guildEnv);
@@ -148,7 +145,7 @@ describe("get role by role name", () => {
     expect(jsonResponse).toEqual(responseConstants.BAD_SIGNATURE);
   });
 
-  it("should return Not Found error if no roleName is not provided", async () => {
+  it("should return BAD REQUEST error if roleName is not provided", async () => {
     getGuildRoleByNameSpy.mockResolvedValueOnce(undefined);
     const mockRequest = generateDummyRequestObject({
       url: "/roles",
@@ -162,7 +159,7 @@ describe("get role by role name", () => {
     );
     const jsonResponse: { error: string } = await response.json();
     expect(response.status).toBe(404);
-    expect(jsonResponse).toEqual(responseConstants.NOT_FOUND);
+    expect(jsonResponse).toEqual(responseConstants.BAD_REQUEST);
   });
 
   it("should return not found object if there is no roles with given name in guild", async () => {

--- a/tests/unit/handlers/guildRoleHandler.test.ts
+++ b/tests/unit/handlers/guildRoleHandler.test.ts
@@ -67,7 +67,9 @@ describe("get roles", () => {
     );
     const jsonResponse = await response.json();
     expect(response.status).toBe(500);
-    expect(jsonResponse).toBe(responseConstants.INTERNAL_SERVER_ERROR);
+    expect(jsonResponse).toEqual({
+      error: responseConstants.INTERNAL_SERVER_ERROR,
+    });
   });
 
   it("should return empty array if there is no roles in guild", async () => {
@@ -230,7 +232,9 @@ describe("get role by role name", () => {
     );
     const jsonResponse: { roles: Array<GuildRole> } = await response.json();
     expect(response.status).toBe(500);
-    expect(jsonResponse).toBe(responseConstants.INTERNAL_SERVER_ERROR);
+    expect(jsonResponse).toEqual({
+      error: responseConstants.INTERNAL_SERVER_ERROR,
+    });
   });
 
   it("should return object of id and name corresponding to the role name recieved", async () => {

--- a/tests/unit/handlers/guildRoleHandler.test.ts
+++ b/tests/unit/handlers/guildRoleHandler.test.ts
@@ -2,7 +2,7 @@ import {
   getGuildRoleByRoleNameHandler,
   getGuildRolesHandler,
 } from "../../../src/controllers/guildRoleHandler";
-import { GuildRole } from "../../../src/typeDefinitions/role.types";
+import { Role } from "../../../src/typeDefinitions/role.types";
 import JSONResponse from "../../../src/utils/JsonResponse";
 import {
   generateDummyRequestObject,
@@ -84,16 +84,14 @@ describe("get roles", () => {
       mockRequest,
       guildEnv
     );
-    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
+    const jsonResponse: { roles: Array<Role> } = await response.json();
     expect(response.status).toBe(200);
     expect(Array.isArray(jsonResponse.roles)).toBeTruthy();
     expect(jsonResponse.roles.length).toBe(0);
   });
 
   it("should return array of id and name of roles present in guild", async () => {
-    const expectedResponse = rolesMock;
-    getGuildRolesSpy.mockResolvedValueOnce(expectedResponse);
-
+    getGuildRolesSpy.mockResolvedValueOnce(rolesMock);
     const mockRequest = generateDummyRequestObject({
       url: "/roles",
       headers: { Authorization: "Bearer testtoken" },
@@ -103,15 +101,15 @@ describe("get roles", () => {
       mockRequest,
       guildEnv
     );
-    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
+    const jsonResponse: { roles: Array<Role> } = await response.json();
     expect(response.status).toBe(200);
     expect(Array.isArray(jsonResponse.roles)).toBeTruthy();
-    expect(jsonResponse.roles).toEqual(expectedResponse);
+    expect(jsonResponse.roles).toEqual(rolesMock);
   });
 });
 
 describe("get role by role name", () => {
-  beforeEach(() => {
+  afterEach(() => {
     jest.resetAllMocks();
   });
 
@@ -199,9 +197,9 @@ describe("get role by role name", () => {
       mockRequest,
       guildEnv
     );
-    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
+    const role: Role = await response.json();
     expect(response.status).toBe(500);
-    expect(jsonResponse).toEqual({
+    expect(role).toEqual({
       error: responseConstants.ROLE_FETCH_FAILED,
     });
   });
@@ -221,15 +219,16 @@ describe("get role by role name", () => {
       mockRequest,
       guildEnv
     );
-    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
+    const role: Role = await response.json();
     expect(response.status).toBe(500);
-    expect(jsonResponse).toEqual({
+    expect(role).toEqual({
       error: responseConstants.INTERNAL_SERVER_ERROR,
     });
   });
 
   it("should return object of id and name corresponding to the role name recieved", async () => {
-    getGuildRoleByNameSpy.mockResolvedValueOnce(rolesMock[0]);
+    const resultMock = { id: rolesMock[0].id, name: rolesMock[0].name };
+    getGuildRoleByNameSpy.mockResolvedValueOnce(resultMock);
 
     const mockRequest = generateDummyRequestObject({
       url: "/roles",
@@ -243,8 +242,8 @@ describe("get role by role name", () => {
       mockRequest,
       guildEnv
     );
-    const jsonResponse: { roles: Array<GuildRole> } = await response.json();
+    const role: Role = await response.json();
     expect(response.status).toBe(200);
-    expect(jsonResponse).toEqual(rolesMock[0]);
+    expect(role).toEqual(resultMock);
   });
 });

--- a/tests/unit/handlers/guildRoleHandler.test.ts
+++ b/tests/unit/handlers/guildRoleHandler.test.ts
@@ -38,7 +38,7 @@ describe("get roles", () => {
 
   it("should return role fetch failed error response if it fails to fetch roles", async () => {
     getGuildRolesSpy.mockRejectedValueOnce({
-      message: responseConstants.ROLE_FETCH_FAILED_MESSAGE,
+      message: responseConstants.ROLE_FETCH_FAILED,
     });
     const mockRequest = generateDummyRequestObject({
       url: "/roles",
@@ -50,7 +50,9 @@ describe("get roles", () => {
     );
     const jsonResponse = await response.json();
     expect(response.status).toBe(500);
-    expect(jsonResponse).toEqual(responseConstants.ROLE_FETCH_FAILED_ERROR);
+    expect(jsonResponse).toEqual({
+      error: responseConstants.ROLE_FETCH_FAILED,
+    });
   });
 
   it("should return internal server error response if it fails for any other reason", async () => {
@@ -189,7 +191,7 @@ describe("get role by role name", () => {
 
   it("should return role fetch failed error if there was an error while fetching roles", async () => {
     getGuildRoleByNameSpy.mockRejectedValueOnce({
-      message: responseConstants.ROLE_FETCH_FAILED_MESSAGE,
+      message: responseConstants.ROLE_FETCH_FAILED,
     });
 
     const mockRequest = generateDummyRequestObject({
@@ -206,7 +208,9 @@ describe("get role by role name", () => {
     );
     const jsonResponse: { roles: Array<GuildRole> } = await response.json();
     expect(response.status).toBe(500);
-    expect(jsonResponse).toEqual(responseConstants.ROLE_FETCH_FAILED_ERROR);
+    expect(jsonResponse).toEqual({
+      error: responseConstants.ROLE_FETCH_FAILED,
+    });
   });
 
   it("should return internal server error if there was any other error", async () => {

--- a/tests/unit/utils/guildRole.test.ts
+++ b/tests/unit/utils/guildRole.test.ts
@@ -10,8 +10,8 @@ import {
 import {
   dummyAddRoleBody,
   dummyCreateBody,
-  guildDetailsMock,
   guildEnv,
+  rolesMock,
 } from "../../fixtures/fixture";
 
 describe("createGuildRole", () => {
@@ -162,10 +162,10 @@ describe("getGuildRoles", () => {
     jest
       .spyOn(global, "fetch")
       .mockImplementationOnce(async () =>
-        Promise.resolve(new JSONResponse(guildDetailsMock))
+        Promise.resolve(new JSONResponse(rolesMock))
       );
     const roles = await getGuildRoles(guildEnv);
-    const expectedRoles = guildDetailsMock.roles.map(({ id, name }) => ({
+    const expectedRoles = rolesMock.map(({ id, name }) => ({
       id,
       name,
     }));
@@ -200,7 +200,7 @@ describe("getGuildRolesByName", () => {
     jest
       .spyOn(global, "fetch")
       .mockImplementationOnce(async () =>
-        Promise.resolve(new JSONResponse(guildDetailsMock))
+        Promise.resolve(new JSONResponse(rolesMock))
       );
     const role = await getGuildRoleByName("@everyone", guildEnv);
     const expectedRoles = {
@@ -214,7 +214,7 @@ describe("getGuildRolesByName", () => {
     jest
       .spyOn(global, "fetch")
       .mockImplementationOnce(async () =>
-        Promise.resolve(new JSONResponse(guildDetailsMock))
+        Promise.resolve(new JSONResponse(rolesMock))
       );
     const role = await getGuildRoleByName("everyone", guildEnv);
     expect(role).toBeUndefined();

--- a/tests/unit/utils/guildRole.test.ts
+++ b/tests/unit/utils/guildRole.test.ts
@@ -140,7 +140,7 @@ describe("getGuildRoles", () => {
         Promise.resolve(new JSONResponse({}, { status: 500 }))
       );
     await expect(getGuildRoles(guildEnv)).rejects.toThrow(
-      response.ROLE_FETCH_FAILED_MESSAGE
+      response.ROLE_FETCH_FAILED
     );
   });
 
@@ -173,7 +173,7 @@ describe("getGuildRolesByName", () => {
         Promise.resolve(new JSONResponse({}, { status: 500 }))
       );
     await expect(getGuildRoleByName("@everyone", guildEnv)).rejects.toThrow(
-      response.ROLE_FETCH_FAILED_MESSAGE
+      response.ROLE_FETCH_FAILED
     );
   });
 

--- a/tests/unit/utils/guildRole.test.ts
+++ b/tests/unit/utils/guildRole.test.ts
@@ -132,16 +132,30 @@ describe("removeGuildRole", () => {
     expect(result).toEqual(response.INTERNAL_SERVER_ERROR);
   });
 });
+
 describe("getGuildRoles", () => {
-  it("should return undefined if status is not ok", async () => {
+  it("should throw role fetch failed error if status is not ok", async () => {
     jest
       .spyOn(global, "fetch")
       .mockImplementationOnce(async () =>
         Promise.resolve(new JSONResponse({}, { status: 500 }))
       );
 
-    const response = await getGuildRoles(guildEnv);
-    expect(response).toBeUndefined();
+    await expect(getGuildRoles(guildEnv)).rejects.toThrow(
+      response.ROLE_FETCH_FAILED
+    );
+  });
+
+  it("should throw role fetch failed error if discord request fails", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementationOnce(async () =>
+        Promise.reject(new JSONResponse({}, { status: 500 }))
+      );
+
+    await expect(getGuildRoles(guildEnv)).rejects.toThrow(
+      response.ROLE_FETCH_FAILED
+    );
   });
 
   it("should return array of objects containing role_id and role_name", async () => {
@@ -151,16 +165,10 @@ describe("getGuildRoles", () => {
         Promise.resolve(new JSONResponse(guildDetailsMock))
       );
     const roles = await getGuildRoles(guildEnv);
-    const expectedRoles = [
-      {
-        id: "1234567889",
-        name: "@everyone",
-      },
-      {
-        id: "12344567",
-        name: "bot one",
-      },
-    ];
+    const expectedRoles = guildDetailsMock.roles.map(({ id, name }) => ({
+      id,
+      name,
+    }));
     expect(roles).toEqual(expectedRoles);
   });
 });
@@ -172,8 +180,20 @@ describe("getGuildRolesByName", () => {
       .mockImplementationOnce(async () =>
         Promise.resolve(new JSONResponse({}, { status: 500 }))
       );
-    const response = await getGuildRoleByName("@everyone", guildEnv);
-    expect(response).toBeUndefined();
+    await expect(getGuildRoles(guildEnv)).rejects.toThrow(
+      response.ROLE_FETCH_FAILED
+    );
+  });
+
+  it("should throw role fetch failed message if discord request fails", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementationOnce(async () =>
+        Promise.reject(new JSONResponse({}, { status: 500 }))
+      );
+    await expect(getGuildRoles(guildEnv)).rejects.toThrow(
+      response.ROLE_FETCH_FAILED
+    );
   });
 
   it("should return array of objects containing role_id and role_name", async () => {

--- a/tests/unit/utils/guildRole.test.ts
+++ b/tests/unit/utils/guildRole.test.ts
@@ -4,10 +4,13 @@ import {
   createGuildRole,
   addGroupRole,
   removeGuildRole,
+  getGuildRoles,
+  getGuildRoleByName,
 } from "../../../src/utils/guildRole";
 import {
   dummyAddRoleBody,
   dummyCreateBody,
+  guildDetailsMock,
   guildEnv,
 } from "../../fixtures/fixture";
 
@@ -127,5 +130,74 @@ describe("removeGuildRole", () => {
     jest.spyOn(global, "fetch").mockRejectedValue("Oops some error");
     const result = await removeGuildRole(dummyAddRoleBody, guildEnv);
     expect(result).toEqual(response.INTERNAL_SERVER_ERROR);
+  });
+});
+describe("getGuildRoles", () => {
+  it("should throw role fetch failed message if status is not ok", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementationOnce(async () =>
+        Promise.resolve(new JSONResponse({}, { status: 500 }))
+      );
+    await expect(getGuildRoles(guildEnv)).rejects.toThrow(
+      response.ROLE_FETCH_FAILED_MESSAGE
+    );
+  });
+
+  it("should return array of objects containing role_id and role_name", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementationOnce(async () =>
+        Promise.resolve(new JSONResponse(guildDetailsMock))
+      );
+    const roles = await getGuildRoles(guildEnv);
+    const expectedRoles = [
+      {
+        id: "1234567889",
+        name: "@everyone",
+      },
+      {
+        id: "12344567",
+        name: "bot one",
+      },
+    ];
+    expect(roles).toEqual(expectedRoles);
+  });
+});
+
+describe("getGuildRolesByName", () => {
+  it("should throw role fetch failed message if status is not ok", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementationOnce(async () =>
+        Promise.resolve(new JSONResponse({}, { status: 500 }))
+      );
+    await expect(getGuildRoleByName("@everyone", guildEnv)).rejects.toThrow(
+      response.ROLE_FETCH_FAILED_MESSAGE
+    );
+  });
+
+  it("should return array of objects containing role_id and role_name", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementationOnce(async () =>
+        Promise.resolve(new JSONResponse(guildDetailsMock))
+      );
+    const role = await getGuildRoleByName("@everyone", guildEnv);
+    const expectedRoles = {
+      id: "1234567889",
+      name: "@everyone",
+    };
+
+    expect(role).toEqual(expectedRoles);
+  });
+  it("should return undefined when role name does not match any entry", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementationOnce(async () =>
+        Promise.resolve(new JSONResponse(guildDetailsMock))
+      );
+    const role = await getGuildRoleByName("everyone", guildEnv);
+    expect(role).toBeUndefined();
   });
 });

--- a/tests/unit/utils/guildRole.test.ts
+++ b/tests/unit/utils/guildRole.test.ts
@@ -133,15 +133,15 @@ describe("removeGuildRole", () => {
   });
 });
 describe("getGuildRoles", () => {
-  it("should throw role fetch failed message if status is not ok", async () => {
+  it("should return undefined if status is not ok", async () => {
     jest
       .spyOn(global, "fetch")
       .mockImplementationOnce(async () =>
         Promise.resolve(new JSONResponse({}, { status: 500 }))
       );
-    await expect(getGuildRoles(guildEnv)).rejects.toThrow(
-      response.ROLE_FETCH_FAILED
-    );
+
+    const response = await getGuildRoles(guildEnv);
+    expect(response).toBeUndefined();
   });
 
   it("should return array of objects containing role_id and role_name", async () => {
@@ -172,9 +172,8 @@ describe("getGuildRolesByName", () => {
       .mockImplementationOnce(async () =>
         Promise.resolve(new JSONResponse({}, { status: 500 }))
       );
-    await expect(getGuildRoleByName("@everyone", guildEnv)).rejects.toThrow(
-      response.ROLE_FETCH_FAILED
-    );
+    const response = await getGuildRoleByName("@everyone", guildEnv);
+    expect(response).toBeUndefined();
   });
 
   it("should return array of objects containing role_id and role_name", async () => {


### PR DESCRIPTION
## Issue
There was no API to get the role_id of roles in the server and role_ids were hard coded.

## Description (fixes #79 )
This PR adds the below APIs 
1:  GET `/roles`: Fetches all role IDs and names.
2:  GET `/roles/:roleName`: Retrieves role details (role_id and role_name) based on the provided role name.

These changes improve the system's ability to handle role-related operations and enhance the overall role-management experience.

## Anything you would like to inform the reviewer about:
N.A

## Test coverage

File                          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s    
------------------------------|---------|----------|---------|---------|----------------------
All files                     |   83.33 |    86.36 |   89.28 |   82.87 |                 
 responses.ts                |     100 |      100 |     100 |     100 |                    
guildRoleHandler.ts         |   54.23 |    76.92 |      40 |   54.23 | 19-30,34-45,50-65
guildRole.ts                |   90.47 |    66.66 |     100 |      90 | 37-40,58-61     






