### PR TITLE
Added description to the message after using /verify #85

### DIFF
--- a/src/controllers/verifyCommand.ts
+++ b/src/controllers/verifyCommand.ts
@@ -13,6 +13,8 @@ export async function verifyCommand(
   env: env
 ) {
   const token = await generateUniqueToken();
+  const verificationString =
+    "Like to verify yourself? click the above link and authorize real dev squad to manage your discord data";
 
   const response = await sendUserDiscordData(
     token,
@@ -24,7 +26,8 @@ export async function verifyCommand(
   );
   if (response?.status === 201 || response?.status === 200) {
     const verificationSiteURL = config(env).VERIFICATION_SITE_URL;
-    const message = `${verificationSiteURL}/discord?token=${token}`;
+    const message =
+      `${verificationSiteURL}/discord?token=${token}\n` + verificationString;
     return discordEphemeralResponse(message);
   } else {
     return discordEphemeralResponse(RETRY_COMMAND);


### PR DESCRIPTION
### Description

after using /verify command, the reply message is showing just a link.

**Ticket** :  [Added Description to the message after using /verify](https://github.com/Real-Dev-Squad/discord-slash-commands/issues/85)

**Output**: Not adding output as it consist of auth URL!

