### PR TITLE
/user command that gives details of a user

### DIFF
--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -53,3 +53,16 @@ export const TASK = {
     },
   ],
 };
+
+export const USER = {
+  name: "user",
+  description: "Replies with specific user details in the channel",
+  options: [
+    {
+      name: "username",
+      description: "Takes username and shows user details",
+      type: 6,
+      required: true,
+    },
+  ],
+};

--- a/src/controllers/baseHandler.ts
+++ b/src/controllers/baseHandler.ts
@@ -3,6 +3,7 @@ import { helloCommand } from "./helloCommand";
 import { verifyCommand } from "./verifyCommand";
 import { mentionEachUser } from "./mentionEachUser";
 import { taskCommand } from "./taskCommand";
+import { userCommand } from "./userCommand";
 
 import { getCommandName } from "../utils/getCommandName";
 import JSONResponse from "../utils/JsonResponse";
@@ -20,6 +21,7 @@ import {
   MENTION_EACH,
   VERIFY,
   TASK,
+  USER,
 } from "../constants/commands";
 import { updateNickName } from "../utils/updateNickname";
 import { discordEphemeralResponse } from "../utils/discordEphemeralResponse";
@@ -115,6 +117,11 @@ export async function baseHandler(
     case getCommandName(TASK): {
       const data = message.data?.options as Array<messageRequestDataOptions>;
       return await taskCommand(data[0].value, env);
+    }
+
+    case getCommandName(USER): {
+      const data = message.data?.options as Array<messageRequestDataOptions>;
+      return await userCommand(data[0].value, env);
     }
     default: {
       return commandNotFound();

--- a/src/controllers/userCommand.ts
+++ b/src/controllers/userCommand.ts
@@ -1,0 +1,14 @@
+import { env } from "../typeDefinitions/default.types";
+import { discordTextResponse } from "../utils/discordResponse";
+import { getUserDetails } from "../utils/getUserDetails";
+import { formatUserDetails } from "../utils/formatUserDetails";
+
+export async function userCommand(discordId: string, env: env) {
+  try {
+    const userDetails = await getUserDetails(discordId);
+    const formattedUserDetails = formatUserDetails(userDetails);
+    return discordTextResponse(formattedUserDetails);
+  } catch (error) {
+    return discordTextResponse("Trouble in fetching user details.");
+  }
+}

--- a/src/register.ts
+++ b/src/register.ts
@@ -4,6 +4,7 @@ import {
   VERIFY,
   LISTENING,
   TASK,
+  USER,
 } from "./constants/commands";
 import { config } from "dotenv";
 import { DISCORD_BASE_URL } from "./constants/urls";
@@ -23,7 +24,7 @@ async function registerGuildCommands(
   discordApplicationId?: string,
   discordGuildId?: string
 ) {
-  const commands = [HELLO, VERIFY, MENTION_EACH, LISTENING, TASK];
+  const commands = [HELLO, VERIFY, MENTION_EACH, LISTENING, TASK, USER];
 
   try {
     if (!discordBotToken) throw new Error("Please provide a BOT TOKEN");

--- a/src/typeDefinitions/rdsUser.ts
+++ b/src/typeDefinitions/rdsUser.ts
@@ -29,6 +29,7 @@ export type UserType = {
   designation?: string;
   username: string;
   profileStatus?: string;
+  state?: string;
 };
 
 export type UserResponseType = {

--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -1,6 +1,6 @@
 import { UserResponseType } from "../typeDefinitions/rdsUser";
 
-export function formatUserDetails(userDetails: UserResponseType) {
+export function convertTimeStamp(userDetails: UserResponseType) {
   const timestamp = userDetails.user?.discordJoinedAt ?? "";
   const date = new Date(timestamp);
 
@@ -13,11 +13,15 @@ export function formatUserDetails(userDetails: UserResponseType) {
   const seconds = String(date.getSeconds()).padStart(2, "0");
 
   const formattedDate = `${day}/${month}/${year} ${hours}:${minutes}:${seconds}`;
+  return formattedDate;
+}
 
+export function formatUserDetails(userDetails: UserResponseType) {
+  const convertedTimestamp = convertTimeStamp(userDetails);
   return `
           ## User Details
           **Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}
-          **RDS Discord Joined At :** ${formattedDate}
+          **RDS Discord Joined At :** ${convertedTimestamp}
           **State :** ${userDetails.user?.state}
           `;
 }

--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -1,0 +1,23 @@
+import { UserResponseType } from "../typeDefinitions/rdsUser";
+
+export function formatUserDetails(userDetails: UserResponseType) {
+  const timestamp = userDetails.user?.discordJoinedAt ?? "";
+  const date = new Date(timestamp);
+
+  const day = String(date.getDate()).padStart(2, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const year = date.getFullYear();
+
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+
+  const formattedDate = `${day}/${month}/${year} ${hours}:${minutes}:${seconds}`;
+
+  return `
+          ## User Details
+          **Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}
+          **RDS Discord Joined At :** ${formattedDate}
+          **State :** ${userDetails.user?.state}
+          `;
+}

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -1,9 +1,9 @@
 import { UserResponseType } from "../../../src/typeDefinitions/rdsUser";
 import { formatUserDetails } from "../../../src/utils/formatUserDetails";
 import { userResponse } from "../../fixtures/user";
-import { userBackendMock } from "../../fixtures/fixture";
+import { convertTimeStamp } from "../../../src/utils/formatUserDetails";
 
-describe.only("formatUserDetails function", () => {
+describe("formatUserDetails function", () => {
   it("Should return a string", () => {
     const userData: UserResponseType = userResponse;
     const formattedUserDetails = formatUserDetails(userData);
@@ -12,10 +12,11 @@ describe.only("formatUserDetails function", () => {
 
   it("should format user details correctly", () => {
     const formattedDetails = formatUserDetails(userResponse).trim();
+    console.log(formattedDetails);
     const expectedFormattedDetails = `
           ## User Details
           **Full Name :** Sunny Sahsi
-          **RDS Discord Joined At :** 08/08/2023 17:10:42
+          **RDS Discord Joined At :** ${convertTimeStamp(userResponse)}
           **State :** ACTIVE
         `.trim();
     expect(formattedDetails).toEqual(expectedFormattedDetails);

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -1,0 +1,23 @@
+import { UserResponseType } from "../../../src/typeDefinitions/rdsUser";
+import { formatUserDetails } from "../../../src/utils/formatUserDetails";
+import { userResponse } from "../../fixtures/user";
+import { userBackendMock } from "../../fixtures/fixture";
+
+describe.only("formatUserDetails function", () => {
+  it("Should return a string", () => {
+    const userData: UserResponseType = userResponse;
+    const formattedUserDetails = formatUserDetails(userData);
+    expect(typeof formattedUserDetails).toBe("string");
+  });
+
+  it("should format user details correctly", () => {
+    const formattedDetails = formatUserDetails(userResponse).trim();
+    const expectedFormattedDetails = `
+          ## User Details
+          **Full Name :** Sunny Sahsi
+          **RDS Discord Joined At :** 08/08/2023 17:10:42
+          **State :** ACTIVE
+        `.trim();
+    expect(formattedDetails).toEqual(expectedFormattedDetails);
+  });
+});

--- a/tests/unit/utils/getUserDetails.test.ts
+++ b/tests/unit/utils/getUserDetails.test.ts
@@ -48,4 +48,15 @@ describe("Test getUserDetails function", () => {
       "https://api.realdevsquad.com/users?discordId=1234567890&dev=true"
     );
   });
+
+  it("Should include state property", async () => {
+    const mockResponse = userResponse;
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation(() =>
+        Promise.resolve(new JSONResponse(mockResponse))
+      );
+    const user = await getUserDetails(discordID);
+    expect(userResponse.user).toHaveProperty("state");
+  });
 });


### PR DESCRIPTION
## Description
- This pull request introduces a new discord slash command **/user** which takes as an argument username and provides details of that user.
- Issue Ticket :  https://github.com/Real-Dev-Squad/discord-slash-commands/issues/106
- When this command is executed, it returns the following details of the user :
 
```md
##  Jyotsna's Details

   **Full Name :** Jyotsna Mehta
   **RDS Discord Joined At :** 31/05/2023 18:17:08
   **State :** IDLE
```
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/53934353/c90a1a2b-7086-44f9-8d24-30bdea1ed66a)

## Test Coverage Stats : 
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/53934353/69c620e3-153b-42cf-b272-e0a1067950f7)

 