### PR TITLE
REFACTOR: Separate /notify command

### DIFF
--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -80,39 +80,46 @@ export const USER = {
   ],
 };
 
-export const NOTIFY = {
-  name: "notify",
-  description: "notify the user",
+export const NOTIFY_OVERDUE = {
+  name: "notify-overdue",
+  description: "Notify the user about overdue tasks.",
   options: [
     {
-      name: "type",
-      description: "type of notification",
+      name: "notify-overdue",
+      description: "Select the number of days",
       type: 3,
       required: true,
       choices: [
         {
-          name: "OVERDUE",
-          value: "OVERDUE",
+          name: "Already Overdue",
+          value: "0",
         },
-        {
-          name: "ONBOARDING",
-          value: "ONBOARDING",
-        },
-      ],
-    },
-    {
-      name: "sub-type",
-      description: "sub-type of notification",
-      type: 3,
-      required: false,
-      choices: [
         {
           name: "In 1 Day",
           value: "1",
         },
         {
-          name: "In 2 Day",
+          name: "In 2 Days",
           value: "2",
+        },
+      ],
+    },
+  ],
+};
+
+export const NOTIFY_ONBOARDING = {
+  name: "notify-onboarding",
+  description: "Notify the user about onboarding information.",
+  options: [
+    {
+      name: "notify-onboarding",
+      description: "Select the number of days",
+      type: 3,
+      required: true,
+      choices: [
+        {
+          name: "All Onboarding Users",
+          value: "0",
         },
         {
           name: "> 7 Days",

--- a/src/controllers/baseHandler.ts
+++ b/src/controllers/baseHandler.ts
@@ -23,7 +23,8 @@ import {
   MENTION_EACH,
   VERIFY,
   TASK,
-  NOTIFY,
+  NOTIFY_OVERDUE,
+  NOTIFY_ONBOARDING,
   OOO,
   USER,
 } from "../constants/commands";
@@ -122,9 +123,13 @@ export async function baseHandler(
       const data = message.data?.options as Array<messageRequestDataOptions>;
       return await taskCommand(data[0].value);
     }
-    case getCommandName(NOTIFY): {
+    case getCommandName(NOTIFY_OVERDUE): {
       const data = message.data?.options as Array<messageRequestDataOptions>;
-      return await notifyCommand(data);
+      return await notifyCommand(data, true, false);
+    }
+    case getCommandName(NOTIFY_ONBOARDING): {
+      const data = message.data?.options as Array<messageRequestDataOptions>;
+      return await notifyCommand(data, false, true);
     }
     case getCommandName(OOO): {
       const data = message.data?.options as Array<messageRequestDataOptions>;

--- a/src/controllers/notifyCommand.ts
+++ b/src/controllers/notifyCommand.ts
@@ -13,15 +13,18 @@ import { fetchRdsData } from "../utils/fetchRdsData";
 import { createTaggableDiscordIds } from "../utils/createTaggableDiscordIds";
 import { extractDiscordIds } from "../utils/extractDiscordIds";
 
-export async function notifyCommand(data: Array<{ value: string }>) {
-  const typeValue = data[0].value;
-  const daysValue = data[1]?.value;
+export async function notifyCommand(
+  data: Array<{ value: string }>,
+  overdue?: boolean,
+  onboarding?: boolean
+) {
+  const daysValue = data[0]?.value;
 
   try {
-    if (typeValue === "OVERDUE") {
+    if (overdue) {
       const options = {
-        isOverdue: true,
         days: daysValue,
+        isOverdue: true,
       };
       const usersResponse = (await fetchRdsData(
         options
@@ -30,7 +33,7 @@ export async function notifyCommand(data: Array<{ value: string }>) {
       const formattedIds = createTaggableDiscordIds(discordIDs);
 
       const message = `**Message:** ${
-        daysValue
+        Number(daysValue) > 0
           ? OVERDUE_CUSTOM_MESSAGE.replace("{{days}}", daysValue)
           : OVERDUE_DEFAULT_MESSAGE
       }`;
@@ -38,17 +41,17 @@ export async function notifyCommand(data: Array<{ value: string }>) {
       const users = `**Developers:** ${formattedIds.join(", ")}`;
       const responseMessage = `${message}\n${users}`;
       return discordTextResponse(responseMessage);
-    } else if (typeValue === "ONBOARDING") {
+    } else if (onboarding) {
       const options = {
-        isOnboarding: true,
         days: daysValue,
+        isOnboarding: true,
       };
       const users = (await fetchRdsData(options)) as UserResponseType;
       const discordIDs = extractDiscordIds(users);
       const formattedIds = createTaggableDiscordIds(discordIDs);
 
       const message = `**Message:** ${
-        daysValue
+        Number(daysValue) > 0
           ? ONBOARDING_CUSTOM_MESSAGE.replace("{{days}}", daysValue)
           : ONBOARDING_DEFAULT_MESSAGE
       }`;

--- a/src/register.ts
+++ b/src/register.ts
@@ -4,7 +4,8 @@ import {
   VERIFY,
   LISTENING,
   TASK,
-  NOTIFY,
+  NOTIFY_OVERDUE,
+  NOTIFY_ONBOARDING,
   OOO,
   USER,
 } from "./constants/commands";
@@ -34,7 +35,8 @@ async function registerGuildCommands(
     TASK,
     OOO,
     USER,
-    NOTIFY,
+    NOTIFY_OVERDUE,
+    NOTIFY_ONBOARDING,
   ];
 
   try {

--- a/src/utils/fetchRdsData.ts
+++ b/src/utils/fetchRdsData.ts
@@ -26,13 +26,15 @@ async function fetchRdsData(options = {}) {
     let url = RDS_BASE_API_URL;
 
     if (isOnboarding) {
-      url += days
-        ? `/users/search?state=ONBOARDING&time=${days}d`
-        : `/users/search?state=ONBOARDING`;
+      url +=
+        Number(days) > 0
+          ? `/users/search?state=ONBOARDING&time=${days}d`
+          : `/users/search?state=ONBOARDING`;
     } else if (isOverdue) {
-      url += days
-        ? `/users?query=filterBy:overdue_tasks+days:${days}`
-        : `/users?query=filterBy:overdue_tasks`;
+      url +=
+        Number(days) > 0
+          ? `/users?query=filterBy:overdue_tasks+days:${days}`
+          : `/users?query=filterBy:overdue_tasks`;
     }
     const response = await fetch(url);
 


### PR DESCRIPTION
**Pull Request Description:**
In this pull request, we are separating the `/notify` command into two distinct commands to provide more specific notifications to users.

1. `/notify-overdue`: This command is designed to notify users about overdue tasks.

**Options:**
- `Already Overdue`: This option will display a list of users with tasks that are already overdue.
- `In 1 Day`: This option will show the list of users whose tasks will become overdue in 1 day.
- `In 2 Days`: This option will show the list of users whose tasks will become overdue in 2 days.

2. `/notify-onboarding`: This command is intended to notify users about their onboarding status.

**Options:**
- `All Onboarding`: This option will display a list of users who are currently in the onboarding process.
- `> 7 Days`: This option will show the list of users who have been in the onboarding process for more than 7 days.
- `> 31 Days`: This option will show the list of users who have been in the onboarding process for more than 31 days.

**Test Coverage:**
![Test Coverage](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/70854507/44113dad-7778-4946-9dfb-93ad51310037)

**Commands:**
![Commands](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/70854507/1c32c731-b712-4e1a-985d-688e7e8acaf0)

**Options:**
![Options](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/70854507/76130af3-2377-4e43-a3cb-6c3ee3c625f9)

This PR separates the `/notify` command for better user experience and clarity, allowing users to access relevant information more easily.