### PR TITLE
Fix /user response alignment 

### DIFF
--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -18,10 +18,10 @@ export function convertTimeStamp(userDetails: UserResponseType) {
 
 export function formatUserDetails(userDetails: UserResponseType) {
   const convertedTimestamp = convertTimeStamp(userDetails);
-  return `
-          ## User Details
-          **Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}
-          **RDS Discord Joined At :** ${convertedTimestamp}
-          **State :** ${userDetails.user?.state}
-          `;
+
+  const userFullName = `**Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}`;
+  const discordJoinedAt = `**RDS Discord Joined at :** ${convertedTimestamp}`;
+  const userState = `**State :** ${userDetails.user?.state}`;
+
+  return `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
 }

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -12,13 +12,14 @@ describe("formatUserDetails function", () => {
 
   it("should format user details correctly", () => {
     const formattedDetails = formatUserDetails(userResponse).trim();
+    const userFullName = `**Full Name :** Sunny Sahsi`;
+    const discordJoinedAt = `**RDS Discord Joined at :** ${convertTimeStamp(
+      userResponse
+    )}`;
+    const userState = `**State :** ACTIVE`;
+    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
     console.log(formattedDetails);
-    const expectedFormattedDetails = `
-          ## User Details
-          **Full Name :** Sunny Sahsi
-          **RDS Discord Joined At :** ${convertTimeStamp(userResponse)}
-          **State :** ACTIVE
-        `.trim();
+    console.log(expectedFormattedDetails);
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 });

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -12,14 +12,14 @@ describe("formatUserDetails function", () => {
 
   it("should format user details correctly", () => {
     const formattedDetails = formatUserDetails(userResponse).trim();
+
     const userFullName = `**Full Name :** Sunny Sahsi`;
     const discordJoinedAt = `**RDS Discord Joined at :** ${convertTimeStamp(
       userResponse
     )}`;
     const userState = `**State :** ACTIVE`;
+
     const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
-    console.log(formattedDetails);
-    console.log(expectedFormattedDetails);
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 });


### PR DESCRIPTION
**What is change?**
- fix the alignment of `/user` response.

**Before: **
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/22213872/7b4edbce-714e-47ab-8e50-e91a336970b9)


**After: **
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/22213872/f0b5d1bc-fad2-4c54-9ba4-2be9f231813c)

**Test coverage: **
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/22213872/f5ae4104-769f-4acf-8c08-e6d005186443)
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/22213872/d15e88df-906c-4d12-a1ec-4d6c67fa2c52)

