### PR TITLE
Fix Prod issues on /user command

### DIFF
--- a/src/controllers/userCommand.ts
+++ b/src/controllers/userCommand.ts
@@ -2,10 +2,14 @@ import { env } from "../typeDefinitions/default.types";
 import { discordTextResponse } from "../utils/discordResponse";
 import { getUserDetails } from "../utils/getUserDetails";
 import { formatUserDetails } from "../utils/formatUserDetails";
+import { USER_NOT_FOUND } from "../constants/responses";
 
 export async function userCommand(discordId: string, env: env) {
   try {
     const userDetails = await getUserDetails(discordId);
+    if (!userDetails.user?.discordId) {
+      return discordTextResponse(USER_NOT_FOUND);
+    }
     const formattedUserDetails = formatUserDetails(userDetails);
     return discordTextResponse(formattedUserDetails);
   } catch (error) {

--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -13,14 +13,14 @@ export function convertTimeStamp(userDetails: UserResponseType) {
     return formattedDate;
   }
 
-  return "";
+  return "N/A";
 }
 
 export function formatUserDetails(userDetails: UserResponseType) {
   const convertedTimestamp = convertTimeStamp(userDetails);
 
   const userFullName = `**Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}`;
-  const discordJoinedAt = `**RDS Discord Joined at :** ${convertedTimestamp}`;
+  const discordJoinedAt = `**Joined Server on :** ${convertedTimestamp}`;
   const userState = `**State :** ${userDetails.user?.state}`;
 
   return `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;

--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -1,19 +1,19 @@
 import { UserResponseType } from "../typeDefinitions/rdsUser";
 
 export function convertTimeStamp(userDetails: UserResponseType) {
-  const timestamp = userDetails.user?.discordJoinedAt ?? "";
-  const date = new Date(timestamp);
+  const timestamp = userDetails.user?.discordJoinedAt;
 
-  const day = String(date.getDate()).padStart(2, "0");
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const year = date.getFullYear();
+  if (timestamp) {
+    const date = new Date(timestamp);
 
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  const seconds = String(date.getSeconds()).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const year = date.getFullYear();
+    const formattedDate = `${day}/${month}/${year}`;
+    return formattedDate;
+  }
 
-  const formattedDate = `${day}/${month}/${year} ${hours}:${minutes}:${seconds}`;
-  return formattedDate;
+  return "";
 }
 
 export function formatUserDetails(userDetails: UserResponseType) {

--- a/tests/fixtures/user.ts
+++ b/tests/fixtures/user.ts
@@ -173,3 +173,29 @@ export const onboardingUsersResponse = {
   message: "Users returned successfully!",
   users: users,
 };
+
+export const userWithoutDiscordJoinedAt = {
+  id: "DWcTUhbC5lRXfDjZRp06",
+  incompleteUserDetails: false,
+  discordJoinedAt: "",
+  discordId: "504855562094247953",
+  github_display_name: "Jyotsna Mehta",
+  updated_at: 1694888822719,
+  roles: {
+    archived: false,
+    in_discord: true,
+    member: false,
+    super_user: false,
+    archive: false,
+  },
+  last_name: "Mehta",
+  github_id: "j24m",
+  first_name: "Jyotsna",
+  username: "jyotsna",
+  state: "IDLE",
+};
+
+export const userWithoutDiscordJoinedAtResponse = {
+  message: "Users returned successfully!",
+  user: userWithoutDiscordJoinedAt,
+};

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -17,7 +17,7 @@ describe("formatUserDetails function", () => {
     const formattedDetails = formatUserDetails(userResponse).trim();
 
     const userFullName = `**Full Name :** Sunny Sahsi`;
-    const discordJoinedAt = `**RDS Discord Joined at :** ${convertTimeStamp(
+    const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
       userResponse
     )}`;
     const userState = `**State :** ACTIVE`;
@@ -31,7 +31,7 @@ describe("formatUserDetails function", () => {
       userWithoutDiscordJoinedAtResponse
     ).trim();
     const userFullName = `**Full Name :** Jyotsna Mehta`;
-    const discordJoinedAt = `**RDS Discord Joined at :** ${convertTimeStamp(
+    const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
       userWithoutDiscordJoinedAtResponse
     )}`;
     const userState = `**State :** IDLE`;

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -1,6 +1,9 @@
 import { UserResponseType } from "../../../src/typeDefinitions/rdsUser";
 import { formatUserDetails } from "../../../src/utils/formatUserDetails";
-import { userResponse } from "../../fixtures/user";
+import {
+  userResponse,
+  userWithoutDiscordJoinedAtResponse,
+} from "../../fixtures/user";
 import { convertTimeStamp } from "../../../src/utils/formatUserDetails";
 
 describe("formatUserDetails function", () => {
@@ -19,6 +22,19 @@ describe("formatUserDetails function", () => {
     )}`;
     const userState = `**State :** ACTIVE`;
 
+    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
+    expect(formattedDetails).toEqual(expectedFormattedDetails);
+  });
+
+  it("should return empty string if discordJoinedAt is undefined", () => {
+    const formattedDetails = formatUserDetails(
+      userWithoutDiscordJoinedAtResponse
+    ).trim();
+    const userFullName = `**Full Name :** Jyotsna Mehta`;
+    const discordJoinedAt = `**RDS Discord Joined at :** ${convertTimeStamp(
+      userWithoutDiscordJoinedAtResponse
+    )}`;
+    const userState = `**State :** IDLE`;
     const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });


### PR DESCRIPTION
## Issue :
- https://github.com/Real-Dev-Squad/discord-slash-commands/issues/147
## Description :
- This pull request introduces improvements to the handling of user details formatting in the `formatUserDetails` function and addresses the scenario where `discordJoinedAt` is undefined when we use the **/user** command.
## Code Changes :
- **userCommand.ts :** In the userCommand function, it is updated to return an appropriate response when the user details cannot be found.
- **formatUserDetails.ts :** In the formatUserDetails and convertTimeStamp functions, I've added enhanced handling for discordJoinedAt to ensure the user details are correctly formatted even when discordJoinedAt is undefined.
- **tests/fixtures/users.ts :** I've introduced a new fixture userWithoutDiscordJoinedAt representing a user without discordJoinedAt data.
- **tests/unit/utils/formatUserDetails.test.ts :** I've added new test cases to verify the behavior of the formatUserDetails function when discordJoinedAt is undefined.
## Test Stats : 
- **Before :**
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/53934353/9747b620-a0b9-4d17-8d82-324c238b66c8)

- **After :**
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/53934353/3dc31da5-c320-471b-909a-a6a00a2bbeb1)
## Working Proof :
- **User found :**
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/53934353/d7a716fe-d576-4f9c-acbe-831da0c6c31d)
- **User not found : (BOT)**
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/53934353/d38c1a91-16b5-4580-bfe3-eb8e8eea0d8f)
- **User not found : (HUMAN)**
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/53934353/fb24a11c-6b0b-4a29-b2b1-cbff4dce2f03)
- **Server Join Date (N/A) :**
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/53934353/59d5ee32-3250-443f-a078-bd60af6f1049)
 


