### PR TITLE
Fix response of /task command

### DIFF
--- a/src/utils/formatTask.ts
+++ b/src/utils/formatTask.ts
@@ -21,7 +21,10 @@ export function generateTaskResponseMessage(
   formattedTasks: string[],
   status: string
 ) {
-  const title = `## ${formatStatusToTitleCase(status)} Tasks of ${nickName}`;
+  const title =
+    formattedTasks.length !== 0
+      ? `## ${formatStatusToTitleCase(status)} Tasks of ${nickName}`
+      : `## ${nickName} doesn't have any in-progress task`;
   const tasks = formattedTasks.join("\n\n");
   const allTaskLink = `[→ All Tasks](${RDS_STATUS_SITE_URL}/tasks?q=status:all+assignee:${nickName})
 `;

--- a/tests/unit/utils/formatTask.test.ts
+++ b/tests/unit/utils/formatTask.test.ts
@@ -37,7 +37,6 @@ describe("Test generateTaskResponseMessage function", () => {
 
   it("Should return a string with task details", () => {
     const formattedTasks = tasks.tasks.map((task: task) => formatTask(task));
-    console.log("format task frm fail", formattedTasks.length);
     const responseMessage = generateTaskResponseMessage(
       "sunny-s",
       formattedTasks,

--- a/tests/unit/utils/formatTask.test.ts
+++ b/tests/unit/utils/formatTask.test.ts
@@ -37,6 +37,7 @@ describe("Test generateTaskResponseMessage function", () => {
 
   it("Should return a string with task details", () => {
     const formattedTasks = tasks.tasks.map((task: task) => formatTask(task));
+    console.log("format task frm fail", formattedTasks.length);
     const responseMessage = generateTaskResponseMessage(
       "sunny-s",
       formattedTasks,
@@ -62,6 +63,20 @@ describe("Test generateTaskResponseMessage function", () => {
     const allTaskURL = `[→ All Tasks](https://status.realdevsquad.com/tasks?q=status:all+assignee:sunny-s)`;
 
     const expectedResponseMessage = `${expectedMessage}\n${task1}\n\n${task2}\n${allTaskURL}\n`;
+    expect(responseMessage).toBe(expectedResponseMessage);
+  });
+
+  it("should return a string if user don't have any in-progress task", () => {
+    const formattedTasks: [] = [];
+    console.log("format task frm fail", formattedTasks.length);
+    const responseMessage = generateTaskResponseMessage(
+      "anish-pawaskar",
+      formattedTasks,
+      "IN_PROGRESS"
+    );
+    const expectedMessage = `## anish-pawaskar doesn't have any in-progress task`;
+    const allTaskURL = `[→ All Tasks](https://status.realdevsquad.com/tasks?q=status:all+assignee:anish-pawaskar)`;
+    const expectedResponseMessage = `${expectedMessage}\n\n${allTaskURL}\n`;
     expect(responseMessage).toBe(expectedResponseMessage);
   });
 });


### PR DESCRIPTION
## Issue Ticket Number
Closes: https://github.com/Real-Dev-Squad/discord-slash-commands/issues/183

## Description
Change the response of `/task` command depending on `in-progress` task of user and write test for same.

**Documentation Updated?**

-   [ ] Yes
-   [x] No

**Breaking Changes**

-   [ ] Yes
-   [x] No

**Development Tested?**

-   [x] Yes
-   [ ] No

**Tested in Staging?**

-   [ ] Yes
-   [x] No

**Under Feature Flag**

-   [ ] Yes
-   [x] No

**Database Changes**

-   [ ] Yes
-   [x] No

### Screenshots

Before :-
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/22213872/21a0b2ff-f238-4e68-ae14-6a000d62be42)

After :-
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/22213872/3f2ad3cd-6ed0-4225-9288-4226c5ac54c4)


## Test Coverage
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/22213872/9d35766b-ea01-4d9c-84f6-400806c989a2)

