### PR TITLE
add taskTitle field to /task/update API

### DIFF
--- a/src/constants/responses.ts
+++ b/src/constants/responses.ts
@@ -77,3 +77,5 @@ export const INVALID_TOKEN_FORMAT =
   "Invalid Authentication header format. Expected 'Bearer <token>'";
 
 export const AUTHENTICATION_ERROR = "Invalid Authentication token";
+export const TASK_UPDATE_SENT_MESSAGE =
+  "Task update sent on Discord's tracking-updates channel.";

--- a/src/controllers/taskUpdatesHandler.ts
+++ b/src/controllers/taskUpdatesHandler.ts
@@ -14,8 +14,17 @@ export const sendTaskUpdatesHandler = async (request: IRequest, env: env) => {
   try {
     await verifyNodejsBackendAuthToken(authHeader, env);
     const updates: TaskUpdates = await request.json();
-    const { completed, planned, blockers, userName, taskId } = updates.content;
-    await sendTaskUpdate(completed, planned, blockers, userName, taskId, env);
+    const { completed, planned, blockers, userName, taskId, taskTitle } =
+      updates.content;
+    await sendTaskUpdate(
+      completed,
+      planned,
+      blockers,
+      userName,
+      taskId,
+      taskTitle,
+      env
+    );
     return new JSONResponse(
       "Task update sent on Discord's tracking-updates channel."
     );

--- a/src/controllers/taskUpdatesHandler.ts
+++ b/src/controllers/taskUpdatesHandler.ts
@@ -25,9 +25,7 @@ export const sendTaskUpdatesHandler = async (request: IRequest, env: env) => {
       taskTitle,
       env
     );
-    return new JSONResponse(
-      "Task update sent on Discord's tracking-updates channel."
-    );
+    return new JSONResponse(response.TASK_UPDATE_SENT_MESSAGE);
   } catch (error: any) {
     return new JSONResponse({
       res: response.INTERNAL_SERVER_ERROR,

--- a/src/typeDefinitions/taskUpdate.d.ts
+++ b/src/typeDefinitions/taskUpdate.d.ts
@@ -5,5 +5,6 @@ export interface TaskUpdates {
     blockers: string;
     userName: string;
     taskId: string;
+    taskTitle: string;
   };
 }

--- a/src/utils/sendTaskUpdates.ts
+++ b/src/utils/sendTaskUpdates.ts
@@ -7,11 +7,12 @@ export async function sendTaskUpdate(
   blockers: string,
   userName: string,
   taskId: string,
+  taskTitle: string,
   env: env
 ): Promise<void> {
   const taskUrl = config(env).RDS_STATUS_SITE_URL + `/tasks/${taskId}`;
   const formattedString =
-    `${userName} added an update to their task: <${taskUrl}>\n` +
+    `**${userName}** added an update to their task: [${taskTitle}](<${taskUrl}>)\n` +
     `\n**Completed**\n${completed}\n\n` +
     `**Planned**\n${planned}\n\n` +
     `**Blockers**\n${blockers}`;

--- a/tests/unit/handlers/taskUpdateHandler.test.ts
+++ b/tests/unit/handlers/taskUpdateHandler.test.ts
@@ -2,7 +2,7 @@ import { sendTaskUpdatesHandler } from "../../../src/controllers/taskUpdatesHand
 import JSONResponse from "../../../src/utils/JsonResponse";
 import * as response from "../../../src/constants/responses";
 import { sendTaskUpdate } from "../../../src/utils/sendTaskUpdates";
-
+import * as responseConstants from "../../../src/constants/responses";
 import { generateDummyRequestObject } from "../../fixtures/fixture";
 
 jest.mock("../../../src/utils/verifyAuthToken", () => ({
@@ -11,7 +11,6 @@ jest.mock("../../../src/utils/verifyAuthToken", () => ({
 jest.mock("../../../src/utils/sendTaskUpdates", () => ({
   sendTaskUpdate: jest.fn().mockResolvedValue(undefined),
 }));
-
 describe("sendTaskUpdatesHandler", () => {
   const mockEnv = { DISCORD_TOKEN: "mockToken" };
   const mockData = {
@@ -27,7 +26,6 @@ describe("sendTaskUpdatesHandler", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
   it("sendTaskUpdate function should return undefined after successfully sending the message", async () => {
     const { completed, planned, blockers, userName, taskId, taskTitle } =
       mockData.content;
@@ -52,5 +50,23 @@ describe("sendTaskUpdatesHandler", () => {
     const jsonResponse: { error: string } = await result.json();
     expect(result.status).toBe(401);
     expect(jsonResponse).toEqual(response.UNAUTHORIZED);
+  });
+  it("should return success response if task update is sent successfully", async () => {
+    const mockRequest = generateDummyRequestObject({
+      url: "/task/update",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer dummyToken",
+      },
+    });
+    mockRequest.json = jest.fn().mockResolvedValue(mockData);
+    const result: JSONResponse = await sendTaskUpdatesHandler(
+      mockRequest,
+      mockEnv
+    );
+    expect(result.status).toBe(200);
+    const res: JSONResponse = await result.json();
+    expect(res).toBe("Task update sent on Discord's tracking-updates channel.");
   });
 });

--- a/tests/unit/handlers/taskUpdateHandler.test.ts
+++ b/tests/unit/handlers/taskUpdateHandler.test.ts
@@ -67,6 +67,6 @@ describe("sendTaskUpdatesHandler", () => {
     );
     expect(result.status).toBe(200);
     const res: JSONResponse = await result.json();
-    expect(res).toBe("Task update sent on Discord's tracking-updates channel.");
+    expect(res).toBe(response.TASK_UPDATE_SENT_MESSAGE);
   });
 });

--- a/tests/unit/handlers/taskUpdateHandler.test.ts
+++ b/tests/unit/handlers/taskUpdateHandler.test.ts
@@ -21,6 +21,7 @@ describe("sendTaskUpdatesHandler", () => {
       blockers: "NA",
       userName: "12345678910",
       taskId: "79wMEIek990",
+      taskTitle: "Hyperlink as task Title",
     },
   };
   afterEach(() => {
@@ -28,13 +29,15 @@ describe("sendTaskUpdatesHandler", () => {
   });
 
   it("sendTaskUpdate function should return undefined after successfully sending the message", async () => {
-    const { completed, planned, blockers, userName, taskId } = mockData.content;
+    const { completed, planned, blockers, userName, taskId, taskTitle } =
+      mockData.content;
     const response = await sendTaskUpdate(
       completed,
       planned,
       blockers,
       userName,
       taskId,
+      taskTitle,
       mockEnv
     );
     expect(response).toBe(undefined);

--- a/tests/unit/handlers/taskUpdateHandler.test.ts
+++ b/tests/unit/handlers/taskUpdateHandler.test.ts
@@ -2,7 +2,6 @@ import { sendTaskUpdatesHandler } from "../../../src/controllers/taskUpdatesHand
 import JSONResponse from "../../../src/utils/JsonResponse";
 import * as response from "../../../src/constants/responses";
 import { sendTaskUpdate } from "../../../src/utils/sendTaskUpdates";
-import * as responseConstants from "../../../src/constants/responses";
 import { generateDummyRequestObject } from "../../fixtures/fixture";
 
 jest.mock("../../../src/utils/verifyAuthToken", () => ({

--- a/tests/unit/utils/sendTasksUpdates.test.ts
+++ b/tests/unit/utils/sendTasksUpdates.test.ts
@@ -9,6 +9,7 @@ describe("sendTaskUpdate function", () => {
   const blockers = "No blockers";
   const userName = "Tejas";
   const taskId = "69nduIn210";
+  const taskTitle = "Hyperlink as task title";
   const taskUrl = config(mockEnv).RDS_STATUS_SITE_URL + `/tasks/${taskId}`;
   const assertFetchCall = (url: string, bodyObj: any, mockEnv: any) => {
     expect(global.fetch).toHaveBeenCalledWith(url, {
@@ -28,7 +29,7 @@ describe("sendTaskUpdate function", () => {
   test("should send the task update to discord tracking channel when all fields are present", async () => {
     const url = config(mockEnv).TRACKING_CHANNEL_URL;
     const formattedString =
-      `${userName} added an update to their task: <${taskUrl}>\n` +
+      `**${userName}** added an update to their task: [${taskTitle}](<${taskUrl}>)\n` +
       `\n**Completed**\n${completed}\n\n` +
       `**Planned**\n${planned}\n\n` +
       `**Blockers**\n${blockers}`;
@@ -46,6 +47,7 @@ describe("sendTaskUpdate function", () => {
       blockers,
       userName,
       taskId,
+      taskTitle,
       mockEnv
     );
 
@@ -55,7 +57,7 @@ describe("sendTaskUpdate function", () => {
   test("should send the task update to discord tracking channel when only completed is present", async () => {
     const url = config(mockEnv).TRACKING_CHANNEL_URL;
     const formattedString =
-      `${userName} added an update to their task: <${taskUrl}>\n` +
+      `**${userName}** added an update to their task: [${taskTitle}](<${taskUrl}>)\n` +
       `\n**Completed**\n${completed}\n\n` +
       `**Planned**\n\n\n` +
       `**Blockers**\n`;
@@ -67,7 +69,15 @@ describe("sendTaskUpdate function", () => {
       .spyOn(global, "fetch")
       .mockImplementation(() => Promise.resolve(new JSONResponse("")));
 
-    await sendTaskUpdate(completed, "", "", userName, taskId, mockEnv);
+    await sendTaskUpdate(
+      completed,
+      "",
+      "",
+      userName,
+      taskId,
+      taskTitle,
+      mockEnv
+    );
 
     assertFetchCall(url, bodyObj, mockEnv);
   });
@@ -75,7 +85,7 @@ describe("sendTaskUpdate function", () => {
   test("should send the task update to discord tracking channel when only planned is present", async () => {
     const url = config(mockEnv).TRACKING_CHANNEL_URL;
     const formattedString =
-      `${userName} added an update to their task: <${taskUrl}>\n` +
+      `**${userName}** added an update to their task: [${taskTitle}](<${taskUrl}>)\n` +
       `\n**Completed**\n\n\n` +
       `**Planned**\n${planned}\n\n` +
       `**Blockers**\n`;
@@ -87,7 +97,7 @@ describe("sendTaskUpdate function", () => {
       .spyOn(global, "fetch")
       .mockImplementation(() => Promise.resolve(new JSONResponse("")));
 
-    await sendTaskUpdate("", planned, "", userName, taskId, mockEnv);
+    await sendTaskUpdate("", planned, "", userName, taskId, taskTitle, mockEnv);
 
     assertFetchCall(url, bodyObj, mockEnv);
   });
@@ -95,7 +105,7 @@ describe("sendTaskUpdate function", () => {
   test("should send the task update to discord tracking channel when only blockers is present", async () => {
     const url = config(mockEnv).TRACKING_CHANNEL_URL;
     const formattedString =
-      `${userName} added an update to their task: <${taskUrl}>\n` +
+      `**${userName}** added an update to their task: [${taskTitle}](<${taskUrl}>)\n` +
       `\n**Completed**\n\n\n` +
       `**Planned**\n\n\n` +
       `**Blockers**\n${blockers}`;
@@ -107,7 +117,15 @@ describe("sendTaskUpdate function", () => {
       .spyOn(global, "fetch")
       .mockImplementation(() => Promise.resolve(new JSONResponse("")));
 
-    await sendTaskUpdate("", "", blockers, userName, taskId, mockEnv);
+    await sendTaskUpdate(
+      "",
+      "",
+      blockers,
+      userName,
+      taskId,
+      taskTitle,
+      mockEnv
+    );
 
     assertFetchCall(url, bodyObj, mockEnv);
   });
@@ -115,7 +133,7 @@ describe("sendTaskUpdate function", () => {
   test("should send the task update to discord tracking channel when only completed and planned are present", async () => {
     const url = config(mockEnv).TRACKING_CHANNEL_URL;
     const formattedString =
-      `${userName} added an update to their task: <${taskUrl}>\n` +
+      `**${userName}** added an update to their task: [${taskTitle}](<${taskUrl}>)\n` +
       `\n**Completed**\n${completed}\n\n` +
       `**Planned**\n${planned}\n\n` +
       `**Blockers**\n`;
@@ -127,7 +145,15 @@ describe("sendTaskUpdate function", () => {
       .spyOn(global, "fetch")
       .mockImplementation(() => Promise.resolve(new JSONResponse("")));
 
-    await sendTaskUpdate(completed, planned, "", userName, taskId, mockEnv);
+    await sendTaskUpdate(
+      completed,
+      planned,
+      "",
+      userName,
+      taskId,
+      taskTitle,
+      mockEnv
+    );
 
     assertFetchCall(url, bodyObj, mockEnv);
   });
@@ -135,7 +161,7 @@ describe("sendTaskUpdate function", () => {
   test("should send the task update to discord tracking channel when only completed and blockers are present", async () => {
     const url = config(mockEnv).TRACKING_CHANNEL_URL;
     const formattedString =
-      `${userName} added an update to their task: <${taskUrl}>\n` +
+      `**${userName}** added an update to their task: [${taskTitle}](<${taskUrl}>)\n` +
       `\n**Completed**\n${completed}\n\n` +
       `**Planned**\n\n\n` +
       `**Blockers**\n${blockers}`;
@@ -147,7 +173,15 @@ describe("sendTaskUpdate function", () => {
       .spyOn(global, "fetch")
       .mockImplementation(() => Promise.resolve(new JSONResponse("")));
 
-    await sendTaskUpdate(completed, "", blockers, userName, taskId, mockEnv);
+    await sendTaskUpdate(
+      completed,
+      "",
+      blockers,
+      userName,
+      taskId,
+      taskTitle,
+      mockEnv
+    );
 
     assertFetchCall(url, bodyObj, mockEnv);
   });
@@ -155,7 +189,7 @@ describe("sendTaskUpdate function", () => {
   test("should send the task update to discord tracking channel when only planned and blockers are present", async () => {
     const url = config(mockEnv).TRACKING_CHANNEL_URL;
     const formattedString =
-      `${userName} added an update to their task: <${taskUrl}>\n` +
+      `**${userName}** added an update to their task: [${taskTitle}](<${taskUrl}>)\n` +
       `\n**Completed**\n\n\n` +
       `**Planned**\n${planned}\n\n` +
       `**Blockers**\n${blockers}`;
@@ -167,7 +201,15 @@ describe("sendTaskUpdate function", () => {
       .spyOn(global, "fetch")
       .mockImplementation(() => Promise.resolve(new JSONResponse("")));
 
-    await sendTaskUpdate("", planned, blockers, userName, taskId, mockEnv);
+    await sendTaskUpdate(
+      "",
+      planned,
+      blockers,
+      userName,
+      taskId,
+      taskTitle,
+      mockEnv
+    );
 
     assertFetchCall(url, bodyObj, mockEnv);
   });

--- a/tests/unit/utils/sendTasksUpdates.test.ts
+++ b/tests/unit/utils/sendTasksUpdates.test.ts
@@ -25,6 +25,37 @@ describe("sendTaskUpdate function", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+  test("should throw an error if response status is not OK", async () => {
+    const url = config(mockEnv).TRACKING_CHANNEL_URL;
+    const formattedString =
+      `**${userName}** added an update to their task: [${taskTitle}](<${taskUrl}>)\n` +
+      `\n**Completed**\n${completed}\n\n` +
+      `**Planned**\n${planned}\n\n` +
+      `**Blockers**\n${blockers}`;
+    const bodyObj = {
+      content: formattedString,
+    };
+
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new JSONResponse("", { status: 400, statusText: "Bad Request" })
+      );
+
+    await expect(
+      sendTaskUpdate(
+        completed,
+        planned,
+        blockers,
+        userName,
+        taskId,
+        taskTitle,
+        mockEnv
+      )
+    ).rejects.toThrowError("Failed to send task update: 400 - Bad Request");
+
+    assertFetchCall(url, bodyObj, mockEnv);
+  });
 
   test("should send the task update to discord tracking channel when all fields are present", async () => {
     const url = config(mockEnv).TRACKING_CHANNEL_URL;


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 1 May, 2024
<!--Developer Name Here-->
Developer Name: Tejas

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
#225 

## Description
This PR update  adds **taskTitle** field to the existing API which sends task updates on RDS discord's tacking-updates channel, now we want to modify the message that should have an hyperlink to the task.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [x] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/98630752/29e26b79-3361-4899-b300-39acecf0994c)

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/98630752/78e86b7c-ac2b-4017-94d4-86c0e1da22c1)

![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/98630752/f049957b-0f89-4df3-8f48-195038e56a29)

![image](https://github.com/Real-Dev-Squad/discord-slash-commands/assets/98630752/2fa18732-11a4-4803-87c5-f41a255116d9)

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
