### PR TITLE
Added username & userId to /user command

### DIFF
--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -96,6 +96,12 @@ export const USER = {
       type: 6,
       required: true,
     },
+    {
+      name: "dev",
+      description: "want to see extra details?",
+      type: 5,
+      require: false,
+    },
   ],
 };
 

--- a/src/controllers/baseHandler.ts
+++ b/src/controllers/baseHandler.ts
@@ -154,7 +154,10 @@ export async function baseHandler(
 
     case getCommandName(USER): {
       const data = message.data?.options as Array<messageRequestDataOptions>;
-      return await userCommand(data[0].value, env);
+      const dev = data.find(
+        (item) => item.name === "dev"
+      ) as unknown as DevFlag;
+      return await userCommand(data[0].value, env, dev);
     }
     default: {
       return commandNotFound();

--- a/src/controllers/userCommand.ts
+++ b/src/controllers/userCommand.ts
@@ -2,15 +2,17 @@ import { env } from "../typeDefinitions/default.types";
 import { discordTextResponse } from "../utils/discordResponse";
 import { getUserDetails } from "../utils/getUserDetails";
 import { formatUserDetails } from "../utils/formatUserDetails";
+import { DevFlag } from "../typeDefinitions/filterUsersByRole";
 import { USER_NOT_FOUND } from "../constants/responses";
 
-export async function userCommand(discordId: string, env: env) {
+export async function userCommand(discordId: string, env: env, dev?: DevFlag) {
   try {
+    const flag = dev?.value || false;
     const userDetails = await getUserDetails(discordId);
     if (!userDetails.user?.discordId) {
       return discordTextResponse(USER_NOT_FOUND);
     }
-    const formattedUserDetails = formatUserDetails(userDetails);
+    const formattedUserDetails = formatUserDetails(userDetails, flag);
     return discordTextResponse(formattedUserDetails);
   } catch (error) {
     return discordTextResponse("Trouble in fetching user details.");

--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -22,8 +22,8 @@ export function formatUserDetails(userDetails: UserResponseType) {
   const userFullName = `**Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}`;
   const discordJoinedAt = `**Joined Server on :** ${convertedTimestamp}`;
   const userState = `**State :** ${userDetails.user?.state}`;
-  const userName = `**UserName :** ${userDetails.user?.username}`;
-  const userId = `**UserId :** ${userDetails.user?.id}`;
+  const userName = `**User Name :** ${userDetails.user?.username}`;
+  const userId = `**User Id :** ${userDetails.user?.id}`;
 
   return `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
 }

--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -19,11 +19,11 @@ export function convertTimeStamp(userDetails: UserResponseType) {
 export function formatUserDetails(userDetails: UserResponseType) {
   const convertedTimestamp = convertTimeStamp(userDetails);
 
-  const userFullName = `**Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}`;
-  const discordJoinedAt = `**Joined Server on :** ${convertedTimestamp}`;
-  const userState = `**State :** ${userDetails.user?.state}`;
-  const userName = `**User Name :** ${userDetails.user?.username}`;
   const userId = `**User Id :** ${userDetails.user?.id}`;
+  const userName = `**User Name :** ${userDetails.user?.username}`;
+  const userFullName = `**Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}`;
+  const userState = `**State :** ${userDetails.user?.state}`;
+  const discordJoinedAt = `**Joined Server on :** ${convertedTimestamp}`;
 
-  return `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
+  return `## User Details\n${userId}\n${userName}\n${userFullName}\n${userState}\n${discordJoinedAt}`;
 }

--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -22,6 +22,8 @@ export function formatUserDetails(userDetails: UserResponseType) {
   const userFullName = `**Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}`;
   const discordJoinedAt = `**Joined Server on :** ${convertedTimestamp}`;
   const userState = `**State :** ${userDetails.user?.state}`;
+  const userName = `**UserName :** ${userDetails.user?.username}`;
+  const userId = `**UserId :** ${userDetails.user?.id}`;
 
-  return `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
+  return `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
 }

--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -16,7 +16,10 @@ export function convertTimeStamp(userDetails: UserResponseType) {
   return "N/A";
 }
 
-export function formatUserDetails(userDetails: UserResponseType) {
+export function formatUserDetails(
+  userDetails: UserResponseType,
+  flag: boolean
+) {
   const convertedTimestamp = convertTimeStamp(userDetails);
 
   const userId = `**User Id :** ${userDetails.user?.id}`;
@@ -24,6 +27,9 @@ export function formatUserDetails(userDetails: UserResponseType) {
   const userFullName = `**Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}`;
   const userState = `**State :** ${userDetails.user?.state}`;
   const discordJoinedAt = `**Joined Server on :** ${convertedTimestamp}`;
+
+  if (!flag)
+    return `## User Details\n${userFullName}\n${userState}\n${discordJoinedAt}`;
 
   return `## User Details\n${userId}\n${userName}\n${userFullName}\n${userState}\n${discordJoinedAt}`;
 }

--- a/tests/fixtures/user.ts
+++ b/tests/fixtures/user.ts
@@ -3,7 +3,7 @@ export const user = {
   incompleteUserDetails: false,
   discordJoinedAt: "2023-08-08T11:40:42.522000+00:00",
   discordId: "858838385330487336",
-  github_display_name: "Sunny Sahsi",
+  github_display_name: "John Doe",
   updated_at: 1694888822719,
   roles: {
     archived: false,
@@ -12,10 +12,10 @@ export const user = {
     super_user: false,
     archive: false,
   },
-  last_name: "Sahsi",
-  github_id: "sahsisunny",
-  first_name: "Sunny",
-  username: "sunny",
+  last_name: "Doe",
+  github_id: "johndoe",
+  first_name: "John",
+  username: "johndoe",
   state: "ACTIVE",
 };
 
@@ -179,7 +179,7 @@ export const userWithoutDiscordJoinedAt = {
   incompleteUserDetails: false,
   discordJoinedAt: "",
   discordId: "504855562094247953",
-  github_display_name: "Jyotsna Mehta",
+  github_display_name: "John Doe",
   updated_at: 1694888822719,
   roles: {
     archived: false,
@@ -188,10 +188,10 @@ export const userWithoutDiscordJoinedAt = {
     super_user: false,
     archive: false,
   },
-  last_name: "Mehta",
-  github_id: "j24m",
-  first_name: "Jyotsna",
-  username: "jyotsna",
+  last_name: "Doe",
+  github_id: "johndoe",
+  first_name: "John",
+  username: "johndoe",
   state: "IDLE",
 };
 

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -21,8 +21,8 @@ describe("formatUserDetails function", () => {
       userResponse
     )}`;
     const userState = `**State :** ACTIVE`;
-    const userName = `**UserName :** johndoe`;
-    const userId = `**UserId :** iODXB6ns8jaZB9p0XlBw`;
+    const userName = `**User Name :** johndoe`;
+    const userId = `**User Id :** iODXB6ns8jaZB9p0XlBw`;
 
     const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
@@ -38,8 +38,8 @@ describe("formatUserDetails function", () => {
       userWithoutDiscordJoinedAtResponse
     )}`;
     const userState = `**State :** IDLE`;
-    const userName = `**UserName :** johndoe`;
-    const userId = `**UserId :** DWcTUhbC5lRXfDjZRp06`;
+    const userName = `**User Name :** johndoe`;
+    const userId = `**User Id :** DWcTUhbC5lRXfDjZRp06`;
     const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -16,12 +16,12 @@ describe("formatUserDetails function", () => {
   it("should format user details correctly", () => {
     const formattedDetails = formatUserDetails(userResponse).trim();
 
-    const userFullName = `**Full Name :** Sunny Sahsi`;
+    const userFullName = `**Full Name :** John Doe`;
     const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
       userResponse
     )}`;
     const userState = `**State :** ACTIVE`;
-    const userName = `**UserName :** sunny`;
+    const userName = `**UserName :** johndoe`;
     const userId = `**UserId :** iODXB6ns8jaZB9p0XlBw`;
 
     const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
@@ -32,12 +32,13 @@ describe("formatUserDetails function", () => {
     const formattedDetails = formatUserDetails(
       userWithoutDiscordJoinedAtResponse
     ).trim();
-    const userFullName = `**Full Name :** Jyotsna Mehta`;
+
+    const userFullName = `**Full Name :** John Doe`;
     const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
       userWithoutDiscordJoinedAtResponse
     )}`;
     const userState = `**State :** IDLE`;
-    const userName = `**UserName :** jyotsna`;
+    const userName = `**UserName :** johndoe`;
     const userId = `**UserId :** DWcTUhbC5lRXfDjZRp06`;
     const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -21,8 +21,10 @@ describe("formatUserDetails function", () => {
       userResponse
     )}`;
     const userState = `**State :** ACTIVE`;
+    const userName = `**UserName :** sunny`;
+    const userId = `**UserId :** iODXB6ns8jaZB9p0XlBw`;
 
-    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
+    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 
@@ -35,7 +37,9 @@ describe("formatUserDetails function", () => {
       userWithoutDiscordJoinedAtResponse
     )}`;
     const userState = `**State :** IDLE`;
-    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
+    const userName = `**UserName :** jyotsna`;
+    const userId = `**UserId :** DWcTUhbC5lRXfDjZRp06`;
+    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 });

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -9,12 +9,12 @@ import { convertTimeStamp } from "../../../src/utils/formatUserDetails";
 describe("formatUserDetails function", () => {
   it("Should return a string", () => {
     const userData: UserResponseType = userResponse;
-    const formattedUserDetails = formatUserDetails(userData);
+    const formattedUserDetails = formatUserDetails(userData, true);
     expect(typeof formattedUserDetails).toBe("string");
   });
 
-  it("should format user details correctly", () => {
-    const formattedDetails = formatUserDetails(userResponse).trim();
+  it("should format user details correctly in dev mode", () => {
+    const formattedDetails = formatUserDetails(userResponse, true).trim();
 
     const userId = `**User Id :** iODXB6ns8jaZB9p0XlBw`;
     const userName = `**User Name :** johndoe`;
@@ -28,9 +28,23 @@ describe("formatUserDetails function", () => {
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 
-  it("should return empty string if discordJoinedAt is undefined", () => {
+  it("should format user details correctly when not in dev mode", () => {
+    const formattedDetails = formatUserDetails(userResponse, false).trim();
+
+    const userFullName = `**Full Name :** John Doe`;
+    const userState = `**State :** ACTIVE`;
+    const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
+      userResponse
+    )}`;
+
+    const expectedFormattedDetails = `## User Details\n${userFullName}\n${userState}\n${discordJoinedAt}`;
+    expect(formattedDetails).toEqual(expectedFormattedDetails);
+  });
+
+  it("should return empty string if discordJoinedAt is undefined in dev mode", () => {
     const formattedDetails = formatUserDetails(
-      userWithoutDiscordJoinedAtResponse
+      userWithoutDiscordJoinedAtResponse,
+      true
     ).trim();
 
     const userId = `**User Id :** DWcTUhbC5lRXfDjZRp06`;
@@ -42,6 +56,22 @@ describe("formatUserDetails function", () => {
     )}`;
 
     const expectedFormattedDetails = `## User Details\n${userId}\n${userName}\n${userFullName}\n${userState}\n${discordJoinedAt}`;
+    expect(formattedDetails).toEqual(expectedFormattedDetails);
+  });
+
+  it("should return empty string if discordJoinedAt is undefined when not in dev mode", () => {
+    const formattedDetails = formatUserDetails(
+      userWithoutDiscordJoinedAtResponse,
+      false
+    ).trim();
+
+    const userFullName = `**Full Name :** John Doe`;
+    const userState = `**State :** IDLE`;
+    const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
+      userWithoutDiscordJoinedAtResponse
+    )}`;
+
+    const expectedFormattedDetails = `## User Details\n${userFullName}\n${userState}\n${discordJoinedAt}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 });

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -16,15 +16,15 @@ describe("formatUserDetails function", () => {
   it("should format user details correctly", () => {
     const formattedDetails = formatUserDetails(userResponse).trim();
 
+    const userId = `**User Id :** iODXB6ns8jaZB9p0XlBw`;
+    const userName = `**User Name :** johndoe`;
     const userFullName = `**Full Name :** John Doe`;
+    const userState = `**State :** ACTIVE`;
     const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
       userResponse
     )}`;
-    const userState = `**State :** ACTIVE`;
-    const userName = `**User Name :** johndoe`;
-    const userId = `**User Id :** iODXB6ns8jaZB9p0XlBw`;
 
-    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
+    const expectedFormattedDetails = `## User Details\n${userId}\n${userName}\n${userFullName}\n${userState}\n${discordJoinedAt}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 
@@ -33,14 +33,15 @@ describe("formatUserDetails function", () => {
       userWithoutDiscordJoinedAtResponse
     ).trim();
 
+    const userId = `**User Id :** DWcTUhbC5lRXfDjZRp06`;
+    const userName = `**User Name :** johndoe`;
     const userFullName = `**Full Name :** John Doe`;
+    const userState = `**State :** IDLE`;
     const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
       userWithoutDiscordJoinedAtResponse
     )}`;
-    const userState = `**State :** IDLE`;
-    const userName = `**User Name :** johndoe`;
-    const userId = `**User Id :** DWcTUhbC5lRXfDjZRp06`;
-    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}\n${userName}\n${userId}`;
+
+    const expectedFormattedDetails = `## User Details\n${userId}\n${userName}\n${userFullName}\n${userState}\n${discordJoinedAt}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 });


### PR DESCRIPTION
Date:  09/09/24
Developer Name: Prashant Peeyush

---

## Issue Ticket Number
- Closes #243 

## Description

 **userId** & **userName**  will also be displayed along with other details when `/user` command is run on discord

### Documentation Updated?

- [ ] Yes
- [x] No

### Under Feature Flag

- [ ] Yes
- [x] No

### Database Changes

- [ ] Yes
- [x] No

### Breaking Changes

- [ ] Yes
- [x] No

### Development Tested?

- [x] Yes
- [ ] No

## Screenshots
<details>
<summary>Screenshot 1</summary>

[screen-capture (4).webm](https://github.com/user-attachments/assets/aa924976-2c68-4054-81e8-cf7ff4bbca44)




</details>

## Test Coverage
<details>
<summary>Screenshot 1</summary>

![Screenshot 2024-09-11 222727](https://github.com/user-attachments/assets/ca65f25d-2c62-47a3-97d2-1f38a605bf35)



</details>
