### PR TITLE
Dev to main sync

### DIFF
--- a/.github/workflows/register-commands-staging.yaml
+++ b/.github/workflows/register-commands-staging.yaml
@@ -34,6 +34,7 @@ jobs:
             DISCORD_GUILD_ID
             CURRENT_ENVIRONMENT
             BOT_PRIVATE_KEY
+            RDS_SERVERLESS_PUBLIC_KEY
             CRON_JOBS_PUBLIC_KEY
             IDENTITY_SERVICE_PUBLIC_KEY
         env:
@@ -43,5 +44,6 @@ jobs:
           DISCORD_TOKEN: ${{secrets.DISCORD_TOKEN}}
           BOT_PRIVATE_KEY: ${{secrets.BOT_PRIVATE_KEY}}
           DISCORD_GUILD_ID: ${{secrets.DISCORD_GUILD_ID}}
+          RDS_SERVERLESS_PUBLIC_KEY: ${{secrets.RDS_SERVERLESS_PUBLIC_KEY}}
           CRON_JOBS_PUBLIC_KEY: ${{secrets.CRON_JOBS_PUBLIC_KEY}}
           IDENTITY_SERVICE_PUBLIC_KEY: ${{secrets.IDENTITY_SERVICE_PUBLIC_KEY}}

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -96,6 +96,12 @@ export const USER = {
       type: 6,
       required: true,
     },
+    {
+      name: "dev",
+      description: "want to see extra details?",
+      type: 5,
+      require: false,
+    },
   ],
 };
 

--- a/src/controllers/baseHandler.ts
+++ b/src/controllers/baseHandler.ts
@@ -154,7 +154,10 @@ export async function baseHandler(
 
     case getCommandName(USER): {
       const data = message.data?.options as Array<messageRequestDataOptions>;
-      return await userCommand(data[0].value, env);
+      const dev = data.find(
+        (item) => item.name === "dev"
+      ) as unknown as DevFlag;
+      return await userCommand(data[0].value, env, dev);
     }
     default: {
       return commandNotFound();

--- a/src/controllers/userCommand.ts
+++ b/src/controllers/userCommand.ts
@@ -2,15 +2,17 @@ import { env } from "../typeDefinitions/default.types";
 import { discordTextResponse } from "../utils/discordResponse";
 import { getUserDetails } from "../utils/getUserDetails";
 import { formatUserDetails } from "../utils/formatUserDetails";
+import { DevFlag } from "../typeDefinitions/filterUsersByRole";
 import { USER_NOT_FOUND } from "../constants/responses";
 
-export async function userCommand(discordId: string, env: env) {
+export async function userCommand(discordId: string, env: env, dev?: DevFlag) {
   try {
+    const flag = dev?.value || false;
     const userDetails = await getUserDetails(discordId);
     if (!userDetails.user?.discordId) {
       return discordTextResponse(USER_NOT_FOUND);
     }
-    const formattedUserDetails = formatUserDetails(userDetails);
+    const formattedUserDetails = formatUserDetails(userDetails, flag);
     return discordTextResponse(formattedUserDetails);
   } catch (error) {
     return discordTextResponse("Trouble in fetching user details.");

--- a/src/utils/formatUserDetails.ts
+++ b/src/utils/formatUserDetails.ts
@@ -16,12 +16,20 @@ export function convertTimeStamp(userDetails: UserResponseType) {
   return "N/A";
 }
 
-export function formatUserDetails(userDetails: UserResponseType) {
+export function formatUserDetails(
+  userDetails: UserResponseType,
+  flag: boolean
+) {
   const convertedTimestamp = convertTimeStamp(userDetails);
 
+  const userId = `**User Id :** ${userDetails.user?.id}`;
+  const userName = `**User Name :** ${userDetails.user?.username}`;
   const userFullName = `**Full Name :** ${userDetails.user?.first_name} ${userDetails.user?.last_name}`;
-  const discordJoinedAt = `**Joined Server on :** ${convertedTimestamp}`;
   const userState = `**State :** ${userDetails.user?.state}`;
+  const discordJoinedAt = `**Joined Server on :** ${convertedTimestamp}`;
 
-  return `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
+  if (!flag)
+    return `## User Details\n${userFullName}\n${userState}\n${discordJoinedAt}`;
+
+  return `## User Details\n${userId}\n${userName}\n${userFullName}\n${userState}\n${discordJoinedAt}`;
 }

--- a/tests/fixtures/user.ts
+++ b/tests/fixtures/user.ts
@@ -3,7 +3,7 @@ export const user = {
   incompleteUserDetails: false,
   discordJoinedAt: "2023-08-08T11:40:42.522000+00:00",
   discordId: "858838385330487336",
-  github_display_name: "Sunny Sahsi",
+  github_display_name: "John Doe",
   updated_at: 1694888822719,
   roles: {
     archived: false,
@@ -12,10 +12,10 @@ export const user = {
     super_user: false,
     archive: false,
   },
-  last_name: "Sahsi",
-  github_id: "sahsisunny",
-  first_name: "Sunny",
-  username: "sunny",
+  last_name: "Doe",
+  github_id: "johndoe",
+  first_name: "John",
+  username: "johndoe",
   state: "ACTIVE",
 };
 
@@ -179,7 +179,7 @@ export const userWithoutDiscordJoinedAt = {
   incompleteUserDetails: false,
   discordJoinedAt: "",
   discordId: "504855562094247953",
-  github_display_name: "Jyotsna Mehta",
+  github_display_name: "John Doe",
   updated_at: 1694888822719,
   roles: {
     archived: false,
@@ -188,10 +188,10 @@ export const userWithoutDiscordJoinedAt = {
     super_user: false,
     archive: false,
   },
-  last_name: "Mehta",
-  github_id: "j24m",
-  first_name: "Jyotsna",
-  username: "jyotsna",
+  last_name: "Doe",
+  github_id: "johndoe",
+  first_name: "John",
+  username: "johndoe",
   state: "IDLE",
 };
 

--- a/tests/unit/utils/formatUserDetails.test.ts
+++ b/tests/unit/utils/formatUserDetails.test.ts
@@ -9,33 +9,69 @@ import { convertTimeStamp } from "../../../src/utils/formatUserDetails";
 describe("formatUserDetails function", () => {
   it("Should return a string", () => {
     const userData: UserResponseType = userResponse;
-    const formattedUserDetails = formatUserDetails(userData);
+    const formattedUserDetails = formatUserDetails(userData, true);
     expect(typeof formattedUserDetails).toBe("string");
   });
 
-  it("should format user details correctly", () => {
-    const formattedDetails = formatUserDetails(userResponse).trim();
+  it("should format user details correctly in dev mode", () => {
+    const formattedDetails = formatUserDetails(userResponse, true).trim();
 
-    const userFullName = `**Full Name :** Sunny Sahsi`;
+    const userId = `**User Id :** iODXB6ns8jaZB9p0XlBw`;
+    const userName = `**User Name :** johndoe`;
+    const userFullName = `**Full Name :** John Doe`;
+    const userState = `**State :** ACTIVE`;
     const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
       userResponse
     )}`;
-    const userState = `**State :** ACTIVE`;
 
-    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
+    const expectedFormattedDetails = `## User Details\n${userId}\n${userName}\n${userFullName}\n${userState}\n${discordJoinedAt}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 
-  it("should return empty string if discordJoinedAt is undefined", () => {
+  it("should format user details correctly when not in dev mode", () => {
+    const formattedDetails = formatUserDetails(userResponse, false).trim();
+
+    const userFullName = `**Full Name :** John Doe`;
+    const userState = `**State :** ACTIVE`;
+    const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
+      userResponse
+    )}`;
+
+    const expectedFormattedDetails = `## User Details\n${userFullName}\n${userState}\n${discordJoinedAt}`;
+    expect(formattedDetails).toEqual(expectedFormattedDetails);
+  });
+
+  it("should return empty string if discordJoinedAt is undefined in dev mode", () => {
     const formattedDetails = formatUserDetails(
-      userWithoutDiscordJoinedAtResponse
+      userWithoutDiscordJoinedAtResponse,
+      true
     ).trim();
-    const userFullName = `**Full Name :** Jyotsna Mehta`;
+
+    const userId = `**User Id :** DWcTUhbC5lRXfDjZRp06`;
+    const userName = `**User Name :** johndoe`;
+    const userFullName = `**Full Name :** John Doe`;
+    const userState = `**State :** IDLE`;
     const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
       userWithoutDiscordJoinedAtResponse
     )}`;
+
+    const expectedFormattedDetails = `## User Details\n${userId}\n${userName}\n${userFullName}\n${userState}\n${discordJoinedAt}`;
+    expect(formattedDetails).toEqual(expectedFormattedDetails);
+  });
+
+  it("should return empty string if discordJoinedAt is undefined when not in dev mode", () => {
+    const formattedDetails = formatUserDetails(
+      userWithoutDiscordJoinedAtResponse,
+      false
+    ).trim();
+
+    const userFullName = `**Full Name :** John Doe`;
     const userState = `**State :** IDLE`;
-    const expectedFormattedDetails = `## User Details\n${userFullName}\n${discordJoinedAt}\n${userState}`;
+    const discordJoinedAt = `**Joined Server on :** ${convertTimeStamp(
+      userWithoutDiscordJoinedAtResponse
+    )}`;
+
+    const expectedFormattedDetails = `## User Details\n${userFullName}\n${userState}\n${discordJoinedAt}`;
     expect(formattedDetails).toEqual(expectedFormattedDetails);
   });
 });


### PR DESCRIPTION
Date: 16/09/24
Developer Name: @PeeyushPrashant 

---

## Related Issues
- https://github.com/Real-Dev-Squad/discord-slash-commands/issues/243

## PR list

- https://github.com/Real-Dev-Squad/discord-slash-commands/pull/244
- https://github.com/Real-Dev-Squad/discord-slash-commands/pull/248

## Description

- This PR adds **User Id** and **User Name** along with other user details when `/user` command is used
- Have changed dummy data to John Doe (as any user can be removed from RDS)
- Added tests for my changes
- This feature is behind feature flag

### Documentation Updated?

- [ ] Yes
- [x] No (simple extra field shown in output on discord message)

### Under Feature Flag

- [x] Yes
- [ ] No

### Database Changes

- [ ] Yes
- [x] No

### Breaking Changes

- [ ] Yes
- [x] No

### Development Tested?

- [x] Yes
- [ ] No

## Screenshots
<details>
<summary>Screenshot 1</summary>

[screen-capture (5).webm](https://github.com/user-attachments/assets/6d9621fb-bbb9-4ef1-9b5b-f8d4fa15c47a)

</details>
