### PR TITLE
remove the `/remove` command

### DIFF
--- a/src/controllers/baseHandler.ts
+++ b/src/controllers/baseHandler.ts
@@ -82,7 +82,7 @@ export async function baseHandler(
      * HOT FIX to prevent non superusers from running the /remove commmand.
      * More info :- https://discord.com/channels/673083527624916993/729399523268624405/1293604361758441605
      * ---
-    */
+     */
     // case getCommandName(REMOVE): {
     //   const data = message.data?.options as Array<messageRequestDataOptions>;
     //   const transformedArgument = {

--- a/src/controllers/baseHandler.ts
+++ b/src/controllers/baseHandler.ts
@@ -79,14 +79,14 @@ export async function baseHandler(
       return await mentionEachUser(transformedArgument, env, ctx);
     }
 
-    case getCommandName(REMOVE): {
-      const data = message.data?.options as Array<messageRequestDataOptions>;
-      const transformedArgument = {
-        roleToBeRemovedObj: data[0],
-        channelId: message.channel_id,
-      };
-      return await kickEachUser(transformedArgument, env, ctx);
-    }
+    // case getCommandName(REMOVE): {
+    //   const data = message.data?.options as Array<messageRequestDataOptions>;
+    //   const transformedArgument = {
+    //     roleToBeRemovedObj: data[0],
+    //     channelId: message.channel_id,
+    //   };
+    //   return await kickEachUser(transformedArgument, env, ctx);
+    // }
 
     case getCommandName(LISTENING): {
       const data = message.data?.options;

--- a/src/controllers/baseHandler.ts
+++ b/src/controllers/baseHandler.ts
@@ -78,6 +78,11 @@ export async function baseHandler(
       return await mentionEachUser(transformedArgument, env, ctx);
     }
 
+    /**
+     * HOT FIX to prevent non superusers from running the /remove commmand.
+     * More info :- https://discord.com/channels/673083527624916993/729399523268624405/1293604361758441605
+     * ---
+    */
     // case getCommandName(REMOVE): {
     //   const data = message.data?.options as Array<messageRequestDataOptions>;
     //   const transformedArgument = {

--- a/src/controllers/baseHandler.ts
+++ b/src/controllers/baseHandler.ts
@@ -27,7 +27,6 @@ import {
   NOTIFY_ONBOARDING,
   OOO,
   USER,
-  REMOVE,
   GROUP_INVITE,
 } from "../constants/commands";
 import { updateNickName } from "../utils/updateNickname";
@@ -42,7 +41,7 @@ import {
   RETRY_COMMAND,
 } from "../constants/responses";
 import { DevFlag } from "../typeDefinitions/filterUsersByRole";
-import { kickEachUser } from "./kickEachUser";
+// import { kickEachUser } from "./kickEachUser";
 import { groupInvite } from "./groupInvite";
 
 export async function baseHandler(

--- a/src/register.ts
+++ b/src/register.ts
@@ -8,7 +8,6 @@ import {
   NOTIFY_ONBOARDING,
   OOO,
   USER,
-  REMOVE,
   GROUP_INVITE,
 } from "./constants/commands";
 import { config } from "dotenv";
@@ -39,7 +38,6 @@ async function registerGuildCommands(
     USER,
     NOTIFY_OVERDUE,
     NOTIFY_ONBOARDING,
-    REMOVE,
     GROUP_INVITE,
   ];
 


### PR DESCRIPTION
Date: 9th october 2024 
Developer Name: yash raj

---

## Issue Ticket Number
- N/A

## Description
- comment the code for `/remove` command to prevent nonsuper users from calling the command.
- this change should be reverted once a superuser check is added in `kickEachUser` function.