### PR TITLE
feat: Add onboarding extension command to create an onboarding extension request

### DIFF
--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -217,3 +217,34 @@ export const NOTIFY_ONBOARDING = {
     },
   ],
 };
+
+export const ONBOARDING_EXTENSION = {
+  name: "onboarding-extension",
+  description: "This command helps to create an onboarding extension request.",
+  options: [
+    {
+      name: "number-of-days",
+      description: "Number of days required for the extension request",
+      type: 4,
+      required: true,
+    },
+    {
+      name: "reason",
+      description: "Reason for the extension request",
+      type: 3,
+      required: true,
+    },
+    {
+      name: "username",
+      description: "Username of onboarding user",
+      type: 6,
+      required: false,
+    },
+    {
+      name: "dev",
+      description: "Feature flag",
+      type: 5,
+      required: false,
+    },
+  ],
+};

--- a/src/constants/responses.ts
+++ b/src/constants/responses.ts
@@ -83,3 +83,5 @@ export const AUTHENTICATION_ERROR = "Invalid Authentication token";
 export const TASK_UPDATE_SENT_MESSAGE =
   "Task update sent on Discord's tracking-updates channel.";
 export const NOT_IMPLEMENTED = "Feature not implemented";
+export const UNAUTHORIZED_TO_CREATE_ONBOARDING_EXTENSION_REQUEST =
+  "Only super user and onboarding user are authorized to create an onboarding extension request";

--- a/src/controllers/baseHandler.ts
+++ b/src/controllers/baseHandler.ts
@@ -30,6 +30,7 @@ import {
   REMOVE,
   GROUP_INVITE,
   GRANT_AWS_ACCESS,
+  ONBOARDING_EXTENSION,
 } from "../constants/commands";
 import { updateNickName } from "../utils/updateNickname";
 import { discordEphemeralResponse } from "../utils/discordEphemeralResponse";
@@ -46,6 +47,7 @@ import { DevFlag } from "../typeDefinitions/filterUsersByRole";
 import { kickEachUser } from "./kickEachUser";
 import { groupInvite } from "./groupInvite";
 import { grantAWSAccessCommand } from "./grantAWSAccessCommand";
+import { onboardingExtensionCommand } from "./onboardingExtensionCommand";
 
 export async function baseHandler(
   message: discordMessageRequest,
@@ -187,6 +189,21 @@ export async function baseHandler(
 
       return await groupInvite(data[0].value, data[1].value, env);
     }
+
+    case getCommandName(ONBOARDING_EXTENSION): {
+      const data = message.data?.options as Array<messageRequestDataOptions>;
+      const transformedArgument = {
+        numberOfDaysObj: data[0],
+        reasonObj: data[1],
+        userIdObj: data.find((item) => item.name === "username"),
+        channelId: message.channel_id,
+        memberObj: message.member,
+        devObj: data.find((item) => item.name === "dev") as unknown as DevFlag,
+      };
+
+      return await onboardingExtensionCommand(transformedArgument, env, ctx);
+    }
+
     default: {
       return commandNotFound();
     }

--- a/src/controllers/onboardingExtensionCommand.ts
+++ b/src/controllers/onboardingExtensionCommand.ts
@@ -1,0 +1,45 @@
+import { env } from "../typeDefinitions/default.types";
+import {
+  messageRequestDataOptions,
+  messageRequestMember,
+} from "../typeDefinitions/discordMessage.types";
+import { DevFlag } from "../typeDefinitions/filterUsersByRole";
+import { discordTextResponse } from "../utils/discordResponse";
+import {
+  createOnboardingExtension,
+  CreateOnboardingExtensionArgs,
+} from "../utils/onboardingExtension";
+
+export async function onboardingExtensionCommand(
+  transformedArgument: {
+    memberObj: messageRequestMember;
+    userIdObj?: messageRequestDataOptions;
+    numberOfDaysObj: messageRequestDataOptions;
+    reasonObj: messageRequestDataOptions;
+    channelId: number;
+    devObj?: DevFlag;
+  },
+  env: env,
+  ctx: ExecutionContext
+) {
+  const dev = transformedArgument.devObj?.value || false;
+  const discordId = transformedArgument.memberObj.user.id.toString();
+
+  if (!dev) {
+    return discordTextResponse(`<@${discordId}> Feature not implemented`);
+  }
+
+  const args: CreateOnboardingExtensionArgs = {
+    channelId: transformedArgument.channelId,
+    userId: transformedArgument.userIdObj?.value,
+    numberOfDays: Number(transformedArgument.numberOfDaysObj.value),
+    reason: transformedArgument.reasonObj.value,
+    discordId: discordId,
+  };
+
+  const initialResponse = `<@${discordId}> Processing your request for onboarding extension`;
+
+  ctx.waitUntil(createOnboardingExtension(args, env));
+
+  return discordTextResponse(initialResponse);
+}

--- a/src/register.ts
+++ b/src/register.ts
@@ -11,6 +11,7 @@ import {
   REMOVE,
   GROUP_INVITE,
   GRANT_AWS_ACCESS,
+  ONBOARDING_EXTENSION,
 } from "./constants/commands";
 import { config } from "dotenv";
 import { DISCORD_BASE_URL } from "./constants/urls";
@@ -44,6 +45,7 @@ async function registerGuildCommands(
     REMOVE,
     GROUP_INVITE,
     GRANT_AWS_ACCESS,
+    ONBOARDING_EXTENSION,
   ];
 
   try {

--- a/src/typeDefinitions/rdsUser.ts
+++ b/src/typeDefinitions/rdsUser.ts
@@ -7,6 +7,7 @@ export type UserType = {
     archived: boolean;
     in_discord: boolean;
     member?: boolean;
+    super_user?: boolean;
   };
   created_at?: number;
   yoe?: number;

--- a/src/utils/onboardingExtension.ts
+++ b/src/utils/onboardingExtension.ts
@@ -1,0 +1,70 @@
+import config from "../../config/config";
+import { UNAUTHORIZED_TO_CREATE_ONBOARDING_EXTENSION_REQUEST } from "../constants/responses";
+import { DISCORD_BASE_URL } from "../constants/urls";
+import { env } from "../typeDefinitions/default.types";
+import { generateDiscordAuthToken } from "./authTokenGenerator";
+import { getUserDetails } from "./getUserDetails";
+import { sendReplyInDiscordChannel } from "./sendReplyInDiscordChannel";
+
+export type CreateOnboardingExtensionArgs = {
+  userId?: string;
+  channelId: number;
+  reason: string;
+  numberOfDays: number;
+  discordId: string;
+};
+
+export const createOnboardingExtension = async (
+  args: CreateOnboardingExtensionArgs,
+  env: env
+) => {
+  const { channelId } = args;
+
+  const authToken = await generateDiscordAuthToken(
+    "Cloudflare Worker",
+    Math.floor(Date.now() / 1000) + 2,
+    env.BOT_PRIVATE_KEY,
+    "RS256"
+  );
+
+  let content: string;
+  const discordReplyUrl = `${DISCORD_BASE_URL}/channels/${channelId}/messages`;
+
+  if (args.userId && args.discordId !== args.userId) {
+    const userResponse = await getUserDetails(args.discordId);
+    if (!userResponse?.user?.roles?.super_user) {
+      content = `<@${args.discordId}> ${UNAUTHORIZED_TO_CREATE_ONBOARDING_EXTENSION_REQUEST}`;
+      return await sendReplyInDiscordChannel(discordReplyUrl, content, env);
+    }
+  }
+
+  const userDiscordId = args.userId ? args.userId : args.discordId;
+  const base_url = config(env).RDS_BASE_API_URL;
+  const createOnboardingExtensionUrl = `${base_url}/requests?dev=true`;
+
+  const requestBody = {
+    userId: userDiscordId,
+    type: "ONBOARDING",
+    numberOfDays: args.numberOfDays,
+    reason: args.reason,
+  };
+
+  try {
+    const response = await fetch(createOnboardingExtensionUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify(requestBody),
+    });
+    const jsonResponse = (await response.json()) as unknown as {
+      message: string;
+    };
+    content = `<@${args.discordId}> ${jsonResponse.message}`;
+    return await sendReplyInDiscordChannel(discordReplyUrl, content, env);
+  } catch (err) {
+    content = `<@${args.discordId}> Error occurred while creating onboarding extension request.`;
+    return await sendReplyInDiscordChannel(discordReplyUrl, content, env);
+  }
+};

--- a/src/utils/sendReplyInDiscordChannel.ts
+++ b/src/utils/sendReplyInDiscordChannel.ts
@@ -1,0 +1,18 @@
+import { env } from "../typeDefinitions/default.types";
+
+export const sendReplyInDiscordChannel = async (
+  discordReplyUrl: string,
+  body: any,
+  env: env
+) => {
+  await fetch(discordReplyUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bot ${env.DISCORD_TOKEN}`,
+    },
+    body: JSON.stringify({
+      content: body,
+    }),
+  });
+};

--- a/tests/fixtures/fixture.ts
+++ b/tests/fixtures/fixture.ts
@@ -383,3 +383,21 @@ export const testDataWithDevTitle = {
     value: true,
   },
 };
+
+export const transformedArgsForOnboardingExtension = {
+  memberObj: {
+    user: {
+      id: 134672111,
+      username: "username",
+      discriminator: "<discriminator>",
+      avatar: "<avatar>",
+    },
+    nick: "<nick>",
+    joined_at: "<joined_at>",
+  },
+  userIdObj: { name: "userId", type: 6, value: "1545562672", options: [] },
+  numberOfDaysObj: { value: "20", name: "numberOfDays", type: 3, options: [] },
+  reasonObj: { value: "reason", name: "reason", type: 3, options: [] },
+  channelId: 6754321,
+  devObj: { value: false, name: "dev", type: 5 },
+};

--- a/tests/unit/handlers/onboardingExtension.test.ts
+++ b/tests/unit/handlers/onboardingExtension.test.ts
@@ -1,0 +1,71 @@
+import { onboardingExtensionCommand } from "../../../src/controllers/onboardingExtensionCommand";
+import { discordTextResponse } from "../../../src/utils/discordResponse";
+import {
+  ctx,
+  guildEnv,
+  transformedArgsForOnboardingExtension,
+} from "../../fixtures/fixture";
+import * as utils from "../../../src/utils/onboardingExtension";
+
+describe("onboardingExtensionCommand", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  const discordId =
+    transformedArgsForOnboardingExtension.memberObj.user.id.toString();
+
+  it("should return Feature not implemented", async () => {
+    const expectedRes = await onboardingExtensionCommand(
+      transformedArgsForOnboardingExtension,
+      guildEnv,
+      ctx
+    );
+    const jsonResponse = await expectedRes.json();
+    const mockResponse = discordTextResponse(
+      `<@${discordId}> Feature not implemented`
+    );
+    const mockJsonResponse = await mockResponse.json();
+    expect(jsonResponse).toStrictEqual(mockJsonResponse);
+  });
+
+  it("should return initial response", async () => {
+    transformedArgsForOnboardingExtension.devObj.value = true;
+    const expectedRes = await onboardingExtensionCommand(
+      transformedArgsForOnboardingExtension,
+      guildEnv,
+      ctx
+    );
+    const jsonResponse = await expectedRes.json();
+    const mockResponse = discordTextResponse(
+      `<@${discordId}> Processing your request for onboarding extension`
+    );
+    const mockJsonResponse = await mockResponse.json();
+    expect(jsonResponse).toStrictEqual(mockJsonResponse);
+  });
+
+  it("should call createOnboardingExtension", async () => {
+    jest.spyOn(utils, "createOnboardingExtension");
+    transformedArgsForOnboardingExtension.devObj.value = true;
+    await onboardingExtensionCommand(
+      transformedArgsForOnboardingExtension,
+      guildEnv,
+      ctx
+    );
+    expect(utils.createOnboardingExtension).toHaveBeenCalledTimes(1);
+    expect(utils.createOnboardingExtension).toHaveBeenCalledWith(
+      {
+        channelId: transformedArgsForOnboardingExtension.channelId,
+        userId: transformedArgsForOnboardingExtension.userIdObj?.value,
+        numberOfDays: Number(
+          transformedArgsForOnboardingExtension.numberOfDaysObj.value
+        ),
+        reason: transformedArgsForOnboardingExtension.reasonObj.value,
+        discordId: discordId,
+      },
+      guildEnv
+    );
+  });
+});

--- a/tests/unit/utils/onboardingExtension.test.ts
+++ b/tests/unit/utils/onboardingExtension.test.ts
@@ -1,0 +1,116 @@
+import config from "../../../config/config";
+import { UNAUTHORIZED_TO_CREATE_ONBOARDING_EXTENSION_REQUEST } from "../../../src/constants/responses";
+import { DISCORD_BASE_URL } from "../../../src/constants/urls";
+import { generateDiscordAuthToken } from "../../../src/utils/authTokenGenerator";
+import JSONResponse from "../../../src/utils/JsonResponse";
+import {
+  createOnboardingExtension,
+  CreateOnboardingExtensionArgs,
+} from "../../../src/utils/onboardingExtension";
+import * as utils from "../../../src/utils/sendReplyInDiscordChannel";
+import { env, guildEnv } from "../../fixtures/fixture";
+
+describe("createOnboaringExtension", () => {
+  const args: CreateOnboardingExtensionArgs = {
+    channelId: 123456789,
+    discordId: "4574263",
+    numberOfDays: 2,
+    reason: "This is reason",
+    userId: "1462465462546",
+  };
+  const discordReplyUrl = `${DISCORD_BASE_URL}/channels/${args.channelId}/messages`;
+  const base_url = config(env).RDS_BASE_API_URL;
+  const createOnboardingExtensionUrl = `${base_url}/requests?dev=true`;
+  let fetchSpy: jest.SpyInstance;
+  let authToken: string;
+
+  const requestData = {
+    userId: args.userId,
+    type: "ONBOARDING",
+    numberOfDays: args.numberOfDays,
+    reason: args.reason,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    fetchSpy = jest.spyOn(global, "fetch");
+    jest.spyOn(utils, "sendReplyInDiscordChannel");
+    authToken = await generateDiscordAuthToken(
+      "Cloudflare Worker",
+      Math.floor(Date.now() / 1000) + 2,
+      guildEnv.DISCORD_TOKEN,
+      "RS256"
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should call sendReplyInDicordChannel when user is not a super user", async () => {
+    fetchSpy.mockImplementation(() => new JSONResponse(null));
+    await createOnboardingExtension(args, guildEnv);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(utils.sendReplyInDiscordChannel).toHaveBeenCalledTimes(1);
+    expect(utils.sendReplyInDiscordChannel).toHaveBeenCalledWith(
+      discordReplyUrl,
+      `<@${args.discordId}> ${UNAUTHORIZED_TO_CREATE_ONBOARDING_EXTENSION_REQUEST}`,
+      guildEnv
+    );
+  });
+
+  it("should call sendReplyInDiscordChannel with error response for invalid request body", async () => {
+    const message = "numberOfDays must be positive";
+    const errorContent = `<@${args.discordId}> ${message}`;
+    const response = new JSONResponse({ message });
+
+    fetchSpy.mockImplementation(() => response);
+
+    args.numberOfDays = -1;
+    args.userId = undefined;
+    requestData.numberOfDays = args.numberOfDays;
+
+    await createOnboardingExtension(args, guildEnv);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(utils.sendReplyInDiscordChannel).toHaveBeenCalledTimes(1);
+    expect(utils.sendReplyInDiscordChannel).toHaveBeenCalledWith(
+      discordReplyUrl,
+      errorContent,
+      guildEnv
+    );
+  });
+
+  it("should call sendReplyInDiscordChannel with error content for unexpected error", async () => {
+    fetchSpy.mockImplementation(() => {
+      throw new Error("Unexpected Error");
+    });
+    try {
+      await createOnboardingExtension(args, guildEnv);
+    } catch (error) {
+      expect(utils.sendReplyInDiscordChannel).toHaveBeenCalledTimes(1);
+      expect(utils.sendReplyInDiscordChannel).toHaveBeenCalledWith(
+        discordReplyUrl,
+        `<@${
+          args.discordId
+        }> ${"Error occurred while creating onboarding extension request."}`,
+        guildEnv
+      );
+    }
+  });
+
+  it("should call sendReplyInDiscordChannel  with success response", async () => {
+    args.userId = undefined;
+    requestData.userId = args.discordId;
+    await createOnboardingExtension(args, guildEnv);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenCalledWith(createOnboardingExtensionUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify(requestData),
+    });
+  });
+});

--- a/tests/unit/utils/sendReplyInDiscordChannel.test.ts
+++ b/tests/unit/utils/sendReplyInDiscordChannel.test.ts
@@ -1,0 +1,32 @@
+import { sendReplyInDiscordChannel } from "../../../src/utils/sendReplyInDiscordChannel";
+
+describe("sendReplyInDiscordChannel", () => {
+  const discordReplyUrl = "<disocrd-url>";
+  const content = "<dicord-content>;";
+  const mockEnv = { DISCORD_TOKEN: "mockToken" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should call fetch", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(new Response(content));
+
+    await sendReplyInDiscordChannel(discordReplyUrl, content, mockEnv);
+
+    expect(global.fetch).toHaveBeenCalledWith(discordReplyUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bot ${mockEnv.DISCORD_TOKEN}`,
+      },
+      body: JSON.stringify({
+        content: content,
+      }),
+    });
+  });
+});


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 20 Dec, 2024
<!--Developer Name Here-->
Developer Name: @pankajjs 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes https://github.com/Real-Dev-Squad/website-backend/issues/2187

## Description
 - This PR creates a discord slash command `/onboarding-extension <number-of-days> <reason> <username>` which interacts with website backend and creates an onboarding extension request for onboarding user.
 - This command can only be executed for onboarding user.
 - Only the onboarding users themselves or the super users can execute this command.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Working Videos</summary>

<!-- Attach your screenshots here👇-->


- When super-users make request for onboarding users and do not pass username


https://github.com/user-attachments/assets/fe7bdc50-ef81-4c57-89cb-a44cb6306eaf


- When super-users make request for onboarding users

https://github.com/user-attachments/assets/b8098f1c-7f1a-4c3a-85be-ebd794cc4083

- When non-onboarding users make a request

https://github.com/user-attachments/assets/27a0f7de-eed4-46d3-b12e-1f48548e8571

- When onboarding users make the request first time

https://github.com/user-attachments/assets/0994616a-2394-4b3a-a495-a5679b255674

- When onboarding users make a request 
    - There exists a pending request.
    - When pending requests is approved

https://github.com/user-attachments/assets/190ecbdc-6c4c-48b2-8e70-71437c0f8924


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>
<img width="906" alt="Screenshot 2024-12-20 at 4 45 24 PM" src="https://github.com/user-attachments/assets/0e29965d-a140-44d3-a4f4-7de178b69d04" />
<img width="887" alt="Screenshot 2024-12-20 at 4 45 40 PM" src="https://github.com/user-attachments/assets/40a3d466-d0a1-47d8-b2a7-d5a650ba8231" />

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes
[Design doc](https://docs.google.com/document/d/17LAwNt_LijCR9HY5mHim5tGV70OkMkTETZEJ73n1q4w/edit?pli=1&tab=t.0)
[PRD](https://docs.google.com/document/d/1GBj-15IJJZzDPXxc2OSi33BbI7k4kOMk8VUrLJG4xsM/edit?pli=1&tab=t.0)
<!--Any additional notes, considerations or explanations for reviewers-->
